### PR TITLE
Enhance responsive layout and collapsible toolbar

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -6,7 +6,9 @@ body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Aria
 header{padding:28px 28px 10px 28px;display:grid;grid-template-columns:1fr auto;gap:16px;align-items:start}
 .title{font-size:28px;font-weight:800;letter-spacing:.2px}
 .subtitle{margin-top:6px;color:var(--muted);font-size:14px}
-.toolbar{display:flex;gap:10px;flex-wrap:wrap}
+.toolbar{display:flex;gap:10px;flex-wrap:wrap;position:relative}
+.toolbarButtons{display:flex;gap:10px;flex-wrap:wrap}
+.menuBtn{display:none;border:1px solid var(--border);background:#fff;padding:10px 14px;border-radius:12px;cursor:pointer;font-weight:600;box-shadow:var(--shadow)}
 button{border:1px solid var(--border);background:#fff;padding:10px 14px;border-radius:12px;cursor:pointer;font-weight:600;box-shadow:var(--shadow)}
 button.primary{background:var(--accent);color:#fff;border-color:var(--accent)}
 button.success{background:var(--accent2);color:#fff;border-color:var(--accent2)}
@@ -33,7 +35,23 @@ ul.tasks{list-style:none;margin:0;padding:8px 18px 24px 18px;display:grid;gap:10
 .notesWrap{padding:0 28px 28px 28px;display:grid;grid-template-columns:1fr 1fr;gap:16px}
 .notesWrap textarea{width:100%;min-height:150px;border:1px solid var(--border);border-radius:12px;padding:12px}
 footer{padding:14px 28px 28px 28px;color:var(--muted);font-size:12px}
-@media (max-width:800px){.meta{grid-template-columns:1fr 1fr}.addForm{grid-template-columns:1fr}.notesWrap{grid-template-columns:1fr}}
+@media (max-width:768px){
+  .meta{grid-template-columns:1fr 1fr}
+  .addForm{grid-template-columns:1fr}
+  .notesWrap{grid-template-columns:1fr}
+  .toolbarButtons{display:none;flex-direction:column;position:absolute;top:100%;right:0;background:#fff;padding:10px;border:1px solid var(--border);border-radius:12px;gap:10px}
+  .toolbar.open .toolbarButtons{display:flex}
+  .menuBtn{display:block}
+}
+@media (max-width:480px){
+  header{grid-template-columns:1fr auto}
+  .meta{grid-template-columns:1fr}
+  ul.tasks{grid-template-columns:1fr}
+  .notesWrap{grid-template-columns:1fr}
+}
+@media (min-width:1024px){
+  .page{max-width:1100px}
+}
 @media print{body{background:#fff}.page{margin:0}.toolbar{display:none}.card{box-shadow:none}button{display:none}}
 /* Filters bar */
 .filters{padding:0 28px 12px;display:grid;grid-template-columns:2fr 1.4fr 1.2fr auto;gap:10px}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -348,4 +348,13 @@ async function sendOrder(){
 }
 
 /* ==== kick off ==== */
-document.addEventListener('DOMContentLoaded', load);
+document.addEventListener('DOMContentLoaded', () => {
+  load();
+  const menuBtn = el('#menuBtn');
+  const toolbar = el('.toolbar');
+  if (menuBtn && toolbar) {
+    menuBtn.addEventListener('click', () => {
+      toolbar.classList.toggle('open');
+    });
+  }
+});

--- a/index.php
+++ b/index.php
@@ -20,9 +20,12 @@
           <div class="subtitle">Συντήρηση & αναβαθμίσεις κατοικίας. Επιλέξτε τα κουτάκια για να σημειώσετε ό,τι ολοκληρώθηκε.</div>
         </div>
         <div class="toolbar">
-          <button class="primary" id="printBtn">🖨️ Εκτύπωση / PDF</button>
-          <button id="resetBtn">↺ Επαναφορά επιλογών</button>
-          <button class="success" id="saveBtn">💾 Αποθήκευση τώρα</button>
+          <button class="menuBtn" id="menuBtn">☰</button>
+          <div class="toolbarButtons">
+            <button class="primary" id="printBtn">🖨️ Εκτύπωση / PDF</button>
+            <button id="resetBtn">↺ Επαναφορά επιλογών</button>
+            <button class="success" id="saveBtn">💾 Αποθήκευση τώρα</button>
+          </div>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- Add hamburger-enabled toolbar with toggleable button group
- Extend responsive breakpoints for meta, tasks, notes and widen page on large screens
- Include JS menu toggle hook for mobile navigation

## Testing
- `php -l index.php`
- `php -l login.php`
- `node --check assets/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a13651491c8322a8604b9846adcb4d