### PR TITLE
Add print view and print button to checklist

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -52,7 +52,13 @@ footer{padding:14px 28px 28px 28px;color:var(--muted);font-size:12px}
 @media (min-width:1024px){
   .page{max-width:1100px}
 }
-@media print{body{background:#fff}.page{margin:0}.toolbar{display:none}.card{box-shadow:none}button{display:none}}
+@media print{
+  body{background:#fff}
+  .page{margin:0}
+  .toolbar,.filters,.meta,.notesWrap,footer{display:none}
+  .card{box-shadow:none}
+  button{display:none}
+}
 /* Filters bar */
 .filters{padding:0 28px 12px;display:grid;grid-template-columns:2fr 1.4fr 1.2fr auto;gap:10px}
 .filters input,.filters select{border:1px solid var(--border);border-radius:12px;padding:10px;background:#fff}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -286,7 +286,11 @@ el('#addBtn')?.addEventListener('click', async () => {
   } catch (err) { alert(err.message); }
 });
 
-el('#printBtn')?.addEventListener('click', () => window.print());
+  el('#printBtn')?.addEventListener('click', () => {
+    const url = new URL('print.php', window.location.href);
+    url.searchParams.set('list_id', LIST_ID);
+    window.open(url.toString(), '_blank');
+  });
 el('#resetBtn')?.addEventListener('click', async () => {
   if (!confirm('Σίγουρα θέλετε να καθαρίσετε όλες τις επιλογές; (Η εργασία #4 θα παραμείνει ολοκληρωμένη)')) return;
   try { await API('reset', {}); await load(); } catch (err) { alert(err.message); }

--- a/print.php
+++ b/print.php
@@ -1,0 +1,39 @@
+<?php
+require_once __DIR__ . '/app/bootstrap.php';
+ensure_migrated();
+$list_id = (int)($_GET['list_id'] ?? 1);
+require_auth($list_id);
+$pdo = DB::conn();
+$st = $pdo->prepare('SELECT id,title,description,checked FROM tasks WHERE list_id=? ORDER BY position,id');
+$st->execute([$list_id]);
+$tasks = $st->fetchAll();
+?>
+<!doctype html>
+<html lang="el">
+<head>
+  <meta charset="utf-8" />
+  <title>Εκτύπωση Λίστας</title>
+  <link rel="stylesheet" href="assets/css/styles.css" />
+  <style>
+    body{margin:20px;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial;}
+    ul.tasks{list-style:none;padding:0;margin:0;}
+    .task{display:flex;align-items:flex-start;gap:10px;margin-bottom:6px;}
+    .task.done label{text-decoration:line-through;color:#94a3b8;}
+  </style>
+</head>
+<body onload="window.print()">
+  <ul class="tasks">
+    <?php foreach ($tasks as $t): ?>
+      <li class="task<?= $t['checked'] ? ' done' : '' ?>">
+        <input type="checkbox" <?= $t['checked'] ? 'checked' : '' ?> />
+        <div class="content">
+          <label><?= htmlspecialchars($t['title'], ENT_QUOTES) ?></label>
+          <?php if (!empty($t['description'])): ?>
+            <div class="desc"><?= htmlspecialchars($t['description'], ENT_QUOTES) ?></div>
+          <?php endif; ?>
+        </div>
+      </li>
+    <?php endforeach; ?>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Hide non-essential UI elements when printing
- Link print button to new print-friendly template
- Introduce `print.php` that renders checklist tasks for printing

## Testing
- `php -l print.php`
- `node --check assets/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a1382019e88322b40e35d358a3d2c4