### PR TITLE
Add print view and print button to checklist

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -52,7 +52,17 @@ footer{padding:14px 28px 28px 28px;color:var(--muted);font-size:12px}
 @media (min-width:1024px){
   .page{max-width:1100px}
 }
-@media print{body{background:#fff}.page{margin:0}.toolbar{display:none}.card{box-shadow:none}button{display:none}}
+@media print{
+  body{background:#fff}
+  .page{margin:0}
+  .toolbar,.filters,.meta,.notesWrap,footer{display:none}
+  .card{box-shadow:none}
+  button{display:none}
+  ul.tasks{padding:0}
+  .task{box-shadow:none;border:1px solid #d1d5db;border-radius:8px;padding:6px;background:transparent}
+  .task .handle,.task .actions{display:none}
+  .task input[type="checkbox"]{transform:none;margin-top:0}
+}
 /* Filters bar */
 .filters{padding:0 28px 12px;display:grid;grid-template-columns:2fr 1.4fr 1.2fr auto;gap:10px}
 .filters input,.filters select{border:1px solid var(--border);border-radius:12px;padding:10px;background:#fff}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -286,7 +286,11 @@ el('#addBtn')?.addEventListener('click', async () => {
   } catch (err) { alert(err.message); }
 });
 
-el('#printBtn')?.addEventListener('click', () => window.print());
+  el('#printBtn')?.addEventListener('click', () => {
+    const url = new URL('print.php', window.location.href);
+    url.searchParams.set('list_id', LIST_ID);
+    window.open(url.toString(), '_blank');
+  });
 el('#resetBtn')?.addEventListener('click', async () => {
   if (!confirm('Σίγουρα θέλετε να καθαρίσετε όλες τις επιλογές; (Η εργασία #4 θα παραμείνει ολοκληρωμένη)')) return;
   try { await API('reset', {}); await load(); } catch (err) { alert(err.message); }

--- a/print.php
+++ b/print.php
@@ -1,0 +1,53 @@
+<?php
+require_once __DIR__ . '/app/bootstrap.php';
+ensure_migrated();
+$list_id = (int)($_GET['list_id'] ?? 1);
+require_auth($list_id);
+$pdo = DB::conn();
+$st = $pdo->prepare('SELECT id,title,description,checked FROM tasks WHERE list_id=? ORDER BY position,id');
+$st->execute([$list_id]);
+$tasks = $st->fetchAll();
+?>
+<!doctype html>
+<html lang="el">
+  <head>
+    <meta charset="utf-8" />
+    <title>Εκτύπωση Λίστας</title>
+    <style>
+      body{margin:20px;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial;color:#111;background:#fff;}
+      ul.tasks{list-style:none;padding:0;margin:0;}
+      .task{display:flex;align-items:flex-start;gap:8px;padding:6px 0;border-bottom:1px solid #e5e7eb;}
+      .task:last-child{border-bottom:none;}
+      .task.done label{text-decoration:line-through;color:#6b7280;}
+      .task .desc{font-size:13px;color:#444;margin-top:2px;}
+      input[type="checkbox"]{margin-top:2px;}
+    </style>
+    <script>
+      window.addEventListener('load', () => {
+        window.print();
+        window.addEventListener('afterprint', () => {
+          if (window.opener) {
+            window.close();
+          } else {
+            history.back();
+          }
+        }, { once: true });
+      });
+    </script>
+  </head>
+  <body>
+  <ul class="tasks">
+    <?php foreach ($tasks as $t): ?>
+        <li class="task<?= $t['checked'] ? ' done' : '' ?>">
+          <input type="checkbox" disabled <?= $t['checked'] ? 'checked' : '' ?> />
+          <div class="content">
+            <label><?= htmlspecialchars($t['title'], ENT_QUOTES) ?></label>
+            <?php if (!empty($t['description'])): ?>
+              <div class="desc"><?= htmlspecialchars($t['description'], ENT_QUOTES) ?></div>
+            <?php endif; ?>
+        </div>
+      </li>
+    <?php endforeach; ?>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Strip nonessential styles when printing and hide drag handles/actions
- Use `print.php` template for a clean task list with disabled checkboxes
- Auto-close print window or return to checklist after printing

## Testing
- `php -l print.php`
- `node --check assets/js/app.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68a1382019e88322b40e35d358a3d2c4