### PR TITLE
Add optional task dates with filtering and sorting

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -25,6 +25,8 @@ function ensure_migrated(): void {
   ensure_task_enhancements($pdo);
   // 004 notes table
   ensure_task_notes($pdo);
+  // 005 - start/due dates
+  ensure_task_dates($pdo);
 }
 
 function ensure_task_notes(PDO $pdo): void {
@@ -54,6 +56,13 @@ function ensure_task_enhancements(PDO $pdo): void {
   catch (Throwable $e) { $pdo->exec("ALTER TABLE tasks ADD COLUMN priority TINYINT NOT NULL DEFAULT 2 AFTER position"); }
   try { $pdo->query('SELECT tags FROM tasks LIMIT 1'); }
   catch (Throwable $e) { $pdo->exec("ALTER TABLE tasks ADD COLUMN tags VARCHAR(255) NULL AFTER priority"); }
+}
+
+function ensure_task_dates(PDO $pdo): void {
+  try { $pdo->query('SELECT start_date FROM tasks LIMIT 1'); }
+  catch (Throwable $e) { $pdo->exec("ALTER TABLE tasks ADD COLUMN start_date DATE NULL AFTER tags"); }
+  try { $pdo->query('SELECT due_date FROM tasks LIMIT 1'); }
+  catch (Throwable $e) { $pdo->exec("ALTER TABLE tasks ADD COLUMN due_date DATE NULL AFTER start_date"); }
 }
 
 function csrf_token(): string {

--- a/app/migrations/002_task_dates.sql
+++ b/app/migrations/002_task_dates.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tasks
+  ADD COLUMN start_date DATE NULL AFTER tags,
+  ADD COLUMN due_date DATE NULL AFTER start_date;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -24,6 +24,7 @@ button:active{transform:translateY(1px)}
 .sectionTitle{padding:14px 28px 6px 28px;font-weight:800;color:#111827;letter-spacing:.2px}
 .addForm{display:grid;grid-template-columns:1.2fr 2fr auto;gap:10px;padding:0 28px 12px}
 .addForm input,.addForm textarea{border:1px solid var(--border);border-radius:12px;padding:10px}
+.addForm .dateInputs{display:grid;grid-template-columns:1fr 1fr;gap:8px;width:100%}
 ul.tasks{list-style:none;margin:0;padding:8px 18px 24px 18px;display:grid;gap:10px}
 .task{border:1px solid var(--border);border-radius:16px;padding:12px;display:grid;grid-template-columns:auto 1fr auto;gap:12px;align-items:start;background:#fff}
 .task input[type="checkbox"]{margin-top:4px;transform:scale(1.35);accent-color:var(--accent2);cursor:pointer}
@@ -132,6 +133,10 @@ ul.tasks { gap: 14px; padding: 10px 18px 28px 18px; }
 .task.done{ background:#f8fafc; }
 .task.done label{ color:#94a3b8; text-decoration: line-through; }
 
+/* Task dates */
+.task .dates{ font-size:12px; color:#64748b; margin-top:4px; }
+.task .dates .due{ color:var(--accent); font-weight:600; }
+
 /* Actions */
 .task{ grid-template-columns: 26px 28px 1fr 76px; }
 .actions{ display:flex; gap:8px; justify-content:flex-end; align-items:center; }
@@ -146,6 +151,7 @@ ul.tasks { gap: 14px; padding: 10px 18px 28px 18px; }
 .editForm{ border:1px dashed var(--border); background:#fbfdff; padding:10px; border-radius:12px; margin-top:6px; }
 .editForm .row{ display:grid; grid-template-columns:1fr; gap:8px; }
 .editForm input, .editForm textarea, .editForm select{ border:1px solid var(--border); border-radius:10px; padding:10px; width:100%; }
+.editForm .dateInputs{ display:grid; grid-template-columns:1fr 1fr; gap:8px; }
 .editBtns{ display:flex; gap:8px; justify-content:flex-end; }
 
 /* Notes thread */

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -44,8 +44,14 @@ function taskItem(t){
   li.dataset.id = t.id;
   li.dataset.priority = t.priority || 2;
   li.dataset.tags = (t.tags || '').toLowerCase();
+  li.dataset.start_date = t.start_date || '';
+  li.dataset.due_date   = t.due_date || '';
   li.draggable = true;
   if (t.checked) li.classList.add('done');
+
+  const datesLine = (t.start_date || t.due_date)
+    ? `<div class="dates">${t.start_date ? `<span class=\"start\" title=\"Ημερομηνία έναρξης\">Έναρξη ${escapeHtml(t.start_date)}</span>` : ''}${t.start_date && t.due_date ? ' – ' : ''}${t.due_date ? `<span class=\"due\" title=\"Διορία\">Διορία ${escapeHtml(t.due_date)}</span>` : ''}</div>`
+    : '';
 
   li.innerHTML = `
     <div class="handle" title="Μετακίνηση">≡</div>
@@ -56,6 +62,7 @@ function taskItem(t){
         ${prioBadge(t.priority).outerHTML}
       </div>
       <div class="desc">${escapeHtml(t.description || '')}</div>
+      ${datesLine}
       ${renderChips(t.tags)}
 
       <div class="addNote">
@@ -75,6 +82,10 @@ function taskItem(t){
               <option value="2" ${!t.priority||t.priority==2?'selected':''}>Μεσαία</option>
               <option value="3" ${t.priority==3?'selected':''}>Χαμηλή</option>
             </select>
+          </div>
+          <div class="dateInputs">
+            <input class="editStart" type="date" value="${escapeAttr(t.start_date || '')}" placeholder="Έναρξη" title="Ημερομηνία έναρξης">
+            <input class="editDue" type="date" value="${escapeAttr(t.due_date || '')}" placeholder="Διορία" title="Διορία">
           </div>
           <div class="editBtns">
             <button class="saveEdit success">Αποθήκευση</button>
@@ -126,18 +137,28 @@ function taskItem(t){
     const description = el('.editDesc', li).value.trim();
     const tags = el('.editTags', li).value.trim();
     const priority = Number(el('.editPriority', li).value || 2);
+    const start_date = el('.editStart', li).value;
+    const due_date = el('.editDue', li).value;
     try {
-      await API('update_task', { id: t.id, title, description, tags, priority });
+      await API('update_task', { id: t.id, title, description, tags, priority, start_date, due_date });
       // update UI
       el('.titleText', li).textContent = title;
       el('.desc', li).textContent = description;
       li.dataset.priority = String(priority);
       li.dataset.tags = tags.toLowerCase();
+      li.dataset.start_date = start_date || '';
+      li.dataset.due_date = due_date || '';
       const oldBadge = el('.titleRow .badge', li); if (oldBadge) oldBadge.remove();
       el('.titleRow', li).insertAdjacentElement('beforeend', prioBadge(priority));
       const oldChips = el('.chips', li); if (oldChips) oldChips.remove();
       el('.desc', li).insertAdjacentHTML('afterend', renderChips(tags));
+      const oldDates = el('.dates', li); if (oldDates) oldDates.remove();
+      const datesLine = (start_date || due_date)
+        ? `<div class="dates">${start_date ? `<span class=\"start\" title=\"Ημερομηνία έναρξης\">Έναρξη ${escapeHtml(start_date)}</span>` : ''}${start_date && due_date ? ' – ' : ''}${due_date ? `<span class=\"due\" title=\"Διορία\">Διορία ${escapeHtml(due_date)}</span>` : ''}</div>`
+        : '';
+      el('.desc', li).insertAdjacentHTML('afterend', datesLine);
       el('.cancelEdit', li).click();
+      applyFilters();
     } catch (err) { alert(err.message); }
   });
 
@@ -273,14 +294,18 @@ el('#addBtn')?.addEventListener('click', async () => {
   const description = el('#addDesc').value.trim();
   const priority = Number(el('#addPriority')?.value || 2);
   const tags = el('#addTags')?.value.trim() || '';
+  const start_date = el('#addStart')?.value || '';
+  const due_date = el('#addDue')?.value || '';
   if (!title) { alert('Συμπληρώστε τίτλο'); return; }
   try {
-    const { task } = await API('add', { title, description, priority, tags });
+    const { task } = await API('add', { title, description, priority, tags, start_date, due_date });
     el('#taskList').appendChild(taskItem(task));
     el('#addTitle').value = '';
     el('#addDesc').value = '';
     if (el('#addTags')) el('#addTags').value = '';
     if (el('#addPriority')) el('#addPriority').value = '2';
+    if (el('#addStart')) el('#addStart').value = '';
+    if (el('#addDue')) el('#addDue').value = '';
     refreshProgress();
     applyFilters();
   } catch (err) { alert(err.message); }
@@ -297,7 +322,7 @@ el('#resetBtn')?.addEventListener('click', async () => {
 });
 
 /* ==== Filters ==== */
-['#filterSearch','#filterTag','#filterPriority','#filterPending'].forEach(sel=>{
+['#filterSearch','#filterTag','#filterPriority','#filterPending','#filterFrom','#filterTo','#sortDate'].forEach(sel=>{
   el(sel)?.addEventListener('input', applyFilters);
   el(sel)?.addEventListener('change', applyFilters);
 });
@@ -306,6 +331,9 @@ function applyFilters(){
   const tg = (el('#filterTag')?.value || '').toLowerCase();
   const pr = (el('#filterPriority')?.value || '');
   const onlyPending = !!el('#filterPending')?.checked;
+  const from = el('#filterFrom')?.value || '';
+  const to   = el('#filterTo')?.value || '';
+  const sort = el('#sortDate')?.value || '';
 
   els('.task').forEach(li=>{
     const title = (li.querySelector('label')?.textContent || '').toLowerCase();
@@ -313,15 +341,35 @@ function applyFilters(){
     const tags  = (li.dataset.tags || '');
     const prio  = (li.dataset.priority || '');
     const done  = li.querySelector('input[type="checkbox"]').checked;
+    const due   = li.dataset.due_date || '';
 
     let ok = true;
     if (q && !(title.includes(q) || desc.includes(q))) ok = false;
     if (tg && !tags.split(',').map(s=>s.trim()).filter(Boolean).some(x => x.includes(tg))) ok = false;
     if (pr && pr !== prio) ok = false;
     if (onlyPending && done) ok = false;
+    if (from && (!due || due < from)) ok = false;
+    if (to && (!due || due > to)) ok = false;
 
     li.style.display = ok ? '' : 'none';
   });
+  sortTasks(sort);
+}
+
+function sortTasks(order){
+  const list = el('#taskList');
+  const items = els('.task').filter(li => li.style.display !== 'none');
+  const get = (li, key) => li.dataset[key] || '';
+  items.sort((a,b)=>{
+    switch(order){
+      case 'start_asc': return get(a,'start_date').localeCompare(get(b,'start_date'));
+      case 'start_desc': return get(b,'start_date').localeCompare(get(a,'start_date'));
+      case 'due_asc': return get(a,'due_date').localeCompare(get(b,'due_date'));
+      case 'due_desc': return get(b,'due_date').localeCompare(get(a,'due_date'));
+      default: return 0;
+    }
+  });
+  items.forEach(li => list.appendChild(li));
 }
 
 /* ==== Drag & Drop reorder ==== */
@@ -346,8 +394,13 @@ function getDragAfterElement(container, y){
   }, { offset: Number.NEGATIVE_INFINITY }).element;
 }
 async function sendOrder(){
-  const ids = els('.task').map(li => Number(li.dataset.id));
-  try { await API('reorder', { ids }); }
+  const items = els('.task');
+  const ids = items.map(li => Number(li.dataset.id));
+  const dates = {};
+  items.forEach(li => {
+    dates[li.dataset.id] = { start_date: li.dataset.start_date || null, due_date: li.dataset.due_date || null };
+  });
+  try { await API('reorder', { ids, dates }); }
   catch (err) { alert(err.message); }
 }
 

--- a/index.php
+++ b/index.php
@@ -42,7 +42,7 @@
       </div>
       
       <div class="sectionTitle">Φίλτρα</div>
-<div class="filters">
+  <div class="filters">
   <input id="filterSearch" placeholder="Αναζήτηση τίτλου/περιγραφής">
   <input id="filterTag" placeholder="Ετικέτα (π.χ. Ηλεκτρικά)">
   <select id="filterPriority">
@@ -50,6 +50,15 @@
     <option value="1">Υψηλή</option>
     <option value="2">Μεσαία</option>
     <option value="3">Χαμηλή</option>
+  </select>
+  <input type="date" id="filterFrom" title="Από">
+  <input type="date" id="filterTo" title="Έως">
+  <select id="sortDate">
+    <option value="">Ταξινόμηση: Καμία</option>
+    <option value="start_asc">Έναρξη ↑</option>
+    <option value="start_desc">Έναρξη ↓</option>
+    <option value="due_asc">Λήξη ↑</option>
+    <option value="due_desc">Λήξη ↓</option>
   </select>
   <label class="onlyPending"><input type="checkbox" id="filterPending"> Μόνο εκκρεμή</label>
 </div>
@@ -65,6 +74,10 @@
   <option value="3">Χαμηλή</option>
 </select>
 <input id="addTags" placeholder="Ετικέτες (π.χ. Ηλεκτρικά,Μπάνιο)">
+<div class="dateInputs">
+  <input id="addStart" type="date" placeholder="Έναρξη" title="Ημερομηνία έναρξης">
+  <input id="addDue" type="date" placeholder="Διορία" title="Διορία">
+</div>
         <button class="success" id="addBtn">+ Προσθήκη</button>
         
       </div>


### PR DESCRIPTION
## Summary
- add migration and bootstrap logic for start and due dates on tasks
- extend API endpoints and frontend to create/update dates
- introduce date filters and sorting in UI and reorder endpoint supports dates
- polish date inputs with minimal styling and explicit deadline labels

## Testing
- `php -l app/bootstrap.php`
- `php -l api.php`
- `php -l index.php`
- `node --check assets/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a13cad79148322b1540fe040194672