### PR TITLE
Improve print and reset workflows

### DIFF
--- a/api.php
+++ b/api.php
@@ -208,6 +208,15 @@ try {
       j(['ok'=>true]);
     }
 
+    case 'wipe': { // POST – διαγράφει όλες τις εργασίες και μεταδεδομένα
+      require_method('POST');
+      $pdo->beginTransaction();
+      $pdo->prepare('DELETE FROM tasks WHERE list_id=?')->execute([$list_id]);
+      $pdo->prepare('UPDATE lists SET date_label=NULL, owner=NULL, phone=NULL, notes=NULL, materials=NULL WHERE id=?')->execute([$list_id]);
+      $pdo->commit();
+      j(['ok'=>true]);
+    }
+
     /* ------- Notes (safe fallbacks) ------- */
     case 'comments': { // GET
       require_method('GET');

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -12,6 +12,7 @@ header{padding:28px 28px 10px 28px;display:grid;grid-template-columns:1fr auto;g
 button{border:1px solid var(--border);background:#fff;padding:10px 14px;border-radius:12px;cursor:pointer;font-weight:600;box-shadow:var(--shadow)}
 button.primary{background:var(--accent);color:#fff;border-color:var(--accent)}
 button.success{background:var(--accent2);color:#fff;border-color:var(--accent2)}
+button.danger{background:#ef4444;color:#fff;border-color:#ef4444}
 button:active{transform:translateY(1px)}
 .meta{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;padding:0 28px 18px 28px}
 .meta .field{background:#f8fafc;border:1px solid var(--border);border-radius:12px;padding:10px 12px}
@@ -158,6 +159,14 @@ ul.tasks { gap: 14px; padding: 10px 18px 28px 18px; }
 
 /* Notes thread */
 .addNote{ margin-top:6px; display:flex; gap:8px; }
+
+/* Confirmation modal */
+.modal{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;animation:fadeIn .25s;}
+.modal.hidden{display:none;}
+.modal .box{background:#fff;padding:20px;border-radius:12px;box-shadow:var(--shadow);text-align:center;animation:scaleIn .25s;}
+.modal .actions{margin-top:16px;display:flex;gap:10px;justify-content:center;}
+@keyframes fadeIn{from{opacity:0;}to{opacity:1;}}
+@keyframes scaleIn{from{transform:scale(.9);}to{transform:scale(1);} }
 .addNote input{ flex:1; border:1px solid var(--border); border-radius:10px; padding:8px 10px; }
 .addNote button{ border:1px solid var(--border); border-radius:10px; padding:6px 10px; background:#fff; }
 .addNote button:hover{ background:#e5e7eb; }

--- a/assets/js/tasks.js
+++ b/assets/js/tasks.js
@@ -1,4 +1,4 @@
-import { el, els, API } from './api.js';
+import { el, els, API, LIST_ID } from './api.js';
 import { applyFilters } from './filters.js';
 import { initNotes } from './notes.js';
 import { attachListDnD, sendOrder } from './dnd.js';
@@ -229,4 +229,33 @@ export function init(){
       toolbar.classList.toggle('open');
     });
   }
+
+  el('#printBtn')?.addEventListener('click', () => {
+    window.open(`print.php?list_id=${LIST_ID}`, '_blank');
+  });
+
+  el('#exportBtn')?.addEventListener('click', async () => {
+    try {
+      const data = await API('bootstrap');
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url; a.download = 'checklist.json';
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) { alert(err.message); }
+  });
+
+  el('#resetBtn')?.addEventListener('click', () => {
+    const modal = el('#confirmModal');
+    if (!modal) return;
+    modal.classList.remove('hidden');
+    const hide = () => modal.classList.add('hidden');
+    el('#confirmNo', modal).onclick = hide;
+    el('#confirmYes', modal).onclick = async () => {
+      try { await API('wipe'); load(); }
+      catch (err) { alert(err.message); }
+      hide();
+    };
+  });
 }

--- a/index.php
+++ b/index.php
@@ -24,7 +24,7 @@
           <div class="toolbarButtons">
             <button class="primary" id="printBtn">🖨️ Εκτύπωση / PDF</button>
             <button id="resetBtn">↺ Επαναφορά επιλογών</button>
-            <button class="success" id="saveBtn">💾 Αποθήκευση τώρα</button>
+            <button class="success" id="exportBtn">📄 Εξαγωγή JSON</button>
           </div>
         </div>
       </header>
@@ -92,6 +92,16 @@
       <footer>
         Συμβουλή: Κάντε κλικ στο «Εκτύπωση / PDF» για να αποθηκεύσετε την τρέχουσα κατάσταση ως PDF.
       </footer>
+    </div>
+  </div>
+
+  <div id="confirmModal" class="modal hidden">
+    <div class="box">
+      <p>Να διαγραφούν όλες οι εργασίες; Η ενέργεια δεν αναιρείται.</p>
+      <div class="actions">
+        <button id="confirmYes" class="danger">Διαγραφή</button>
+        <button id="confirmNo">Άκυρο</button>
+      </div>
     </div>
   </div>
 

--- a/print.php
+++ b/print.php
@@ -4,74 +4,43 @@ ensure_migrated();
 $list_id = (int)($_GET['list_id'] ?? 1);
 require_auth($list_id);
 $pdo = DB::conn();
-$st = $pdo->prepare('SELECT id,title,description,checked FROM tasks WHERE list_id=? ORDER BY position,id');
+$st = $pdo->prepare('SELECT title,description,checked FROM tasks WHERE list_id=? ORDER BY position,id');
 $st->execute([$list_id]);
 $tasks = $st->fetchAll();
 ?>
 <!doctype html>
 <html lang="el">
-
-  <head>
-    <meta charset="utf-8" />
-    <title>Εκτύπωση Λίστας</title>
-    <style>
-      body{margin:20px;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial;color:#111;background:#fff;}
-      ul.tasks{list-style:none;padding:0;margin:0;}
-      .task{display:flex;align-items:flex-start;gap:8px;padding:6px 0;border-bottom:1px solid #e5e7eb;}
-      .task:last-child{border-bottom:none;}
-      .task.done label{text-decoration:line-through;color:#6b7280;}
-      .task .desc{font-size:13px;color:#444;margin-top:2px;}
-      input[type="checkbox"]{margin-top:2px;}
-    </style>
-    <script>
-      window.addEventListener('load', () => {
-        window.print();
-        window.addEventListener('afterprint', () => {
-          if (window.opener) {
-            window.close();
-          } else {
-            history.back();
-          }
-        }, { once: true });
-      });
-    </script>
-  </head>
-  <body>
-  <ul class="tasks">
-    <?php foreach ($tasks as $t): ?>
-        <li class="task<?= $t['checked'] ? ' done' : '' ?>">
-          <input type="checkbox" disabled <?= $t['checked'] ? 'checked' : '' ?> />
-          <div class="content">
-            <label><?= htmlspecialchars($t['title'], ENT_QUOTES) ?></label>
-            <?php if (!empty($t['description'])): ?>
-              <div class="desc"><?= htmlspecialchars($t['description'], ENT_QUOTES) ?></div>
-            <?php endif; ?>
-=======
 <head>
   <meta charset="utf-8" />
   <title>Εκτύπωση Λίστας</title>
-  <link rel="stylesheet" href="assets/css/styles.css" />
   <style>
-    body{margin:20px;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial;}
+    body{margin:40px;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial;color:#111;background:#fff;}
+    .printCard{max-width:800px;margin:0 auto;}
+    .printCard h1{text-align:center;margin-bottom:20px;}
     ul.tasks{list-style:none;padding:0;margin:0;}
-    .task{display:flex;align-items:flex-start;gap:10px;margin-bottom:6px;}
-    .task.done label{text-decoration:line-through;color:#94a3b8;}
+    .task{display:flex;align-items:flex-start;gap:8px;padding:6px 0;border-bottom:1px solid #e5e7eb;}
+    .task:last-child{border-bottom:none;}
+    .task.done label{text-decoration:line-through;color:#6b7280;}
+    .task .desc{font-size:13px;color:#444;margin-top:2px;}
+    input[type="checkbox"]{margin-top:2px;}
   </style>
 </head>
 <body onload="window.print()">
+<div class="printCard">
+  <h1>Λίστα Εργασιών</h1>
   <ul class="tasks">
     <?php foreach ($tasks as $t): ?>
       <li class="task<?= $t['checked'] ? ' done' : '' ?>">
-        <input type="checkbox" <?= $t['checked'] ? 'checked' : '' ?> />
+        <input type="checkbox" disabled <?= $t['checked'] ? 'checked' : '' ?> />
         <div class="content">
           <label><?= htmlspecialchars($t['title'], ENT_QUOTES) ?></label>
           <?php if (!empty($t['description'])): ?>
             <div class="desc"><?= htmlspecialchars($t['description'], ENT_QUOTES) ?></div>
           <?php endif; ?>
-
         </div>
       </li>
     <?php endforeach; ?>
   </ul>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Fix printing page with clean template and auto print
- Replace save button with JSON export and add animated reset modal
- Add API action to wipe list tasks and metadata

## Testing
- `php -l api.php print.php`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a159f297b48322be2f67c8d90a46b9