### PR TITLE
feat: update service worker cache and JS paths

### DIFF
--- a/assets/sw.js
+++ b/assets/sw.js
@@ -1,9 +1,14 @@
-const CACHE = 'paros-checklist-v4'; // νέα έκδοση
+const CACHE = 'paros-checklist-v5'; // νέα έκδοση
 const APP_SHELL = [
   './',
   './index.php',
   './assets/css/styles.css',
-  './assets/js/app.js',
+  './assets/js/api.js',
+  './assets/js/main.js',
+  './assets/js/tasks.js',
+  './assets/js/filters.js',
+  './assets/js/notes.js',
+  './assets/js/dnd.js',
   './assets/manifest.webmanifest'
 ];
 


### PR DESCRIPTION
## Summary
- reference real JavaScript modules in service worker cache
- bump service worker cache version to refresh cached assets

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a21049fc808322bda4dba2e004e11f