### PR TITLE
Add expandable notes section

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -23,6 +23,8 @@ button:active{transform:translateY(1px)}
 .progress{height:12px;background:#eef2ff;border:1px solid var(--border);border-radius:999px;overflow:hidden;position:relative}
 .bar{height:100%;width:0%;background:linear-gradient(90deg,var(--accent),var(--accent2));transition:width .25s ease}
 .sectionTitle{padding:14px 28px 6px 28px;font-weight:800;color:#111827;letter-spacing:.2px}
+.notesHeader{display:flex;align-items:center;justify-content:space-between;}
+.notesHeader button{border:none;background:none;font-size:18px;cursor:pointer;line-height:1;padding:0;}
 .addForm{display:grid;grid-template-columns:1.2fr 2fr auto;gap:10px;padding:0 28px 12px}
 .addForm input,.addForm textarea{border:1px solid var(--border);border-radius:12px;padding:10px}
 .addForm .dateInputs{display:grid;grid-template-columns:1fr 1fr;gap:8px;width:100%}

--- a/assets/js/tasks.js
+++ b/assets/js/tasks.js
@@ -258,4 +258,13 @@ export function init(){
       hide();
     };
   });
+
+  const notesToggle = el('#notesToggle');
+  const notesSection = el('#notesSection');
+  if (notesToggle && notesSection){
+    notesToggle.addEventListener('click', () => {
+      notesSection.classList.toggle('hidden');
+      notesToggle.textContent = notesSection.classList.contains('hidden') ? '⮟' : '⮝';
+    });
+  }
 }

--- a/index.php
+++ b/index.php
@@ -83,8 +83,11 @@
       <div class="sectionTitle">Εργασίες</div>
       <ul class="tasks" id="taskList"></ul>
 
-      <div class="sectionTitle">Συνολικές Σημειώσεις</div>
-      <div class="notesWrap">
+      <div class="sectionTitle notesHeader">
+        <span>Συνολικές Σημειώσεις</span>
+        <button id="notesToggle" aria-expanded="false">⮟</button>
+      </div>
+      <div class="notesWrap hidden" id="notesSection">
         <textarea id="notes" placeholder="Γενικές παρατηρήσεις, ημερολόγιο εργασιών, εκκρεμότητες."></textarea>
         <textarea id="materials" placeholder="Υλικά προς αγορά / παραγγελίες."></textarea>
       </div>


### PR DESCRIPTION
## Summary
- add toggle button to show or hide the notes section
- style new notes header for minimal design
- wire up JS toggle functionality

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a213a2aef08322b11119029ae1e560