### PR TITLE
Enhance mobile responsiveness

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -39,15 +39,15 @@ button:active{transform:translateY(1px)}
 .notesHeader button{border:none;background:none;font-size:18px;cursor:pointer;line-height:1;padding:0;}
 
 .addForm{display:grid;grid-template-columns:1.2fr 2fr auto;gap:10px;padding:0 28px 12px}
-.addForm input,.addForm textarea{border:1px solid var(--border);border-radius:12px;padding:10px}
+.addForm input,.addForm textarea{border:1px solid var(--border);border-radius:12px;padding:10px;width:100%}
 .addForm .dateInputs{display:grid;grid-template-columns:1fr 1fr;gap:8px;width:100%}
 .addForm .dateInputs input{ text-align:center; }
 ul.tasks{list-style:none;margin:0;padding:8px 18px 24px 18px;display:grid;gap:10px}
 .task{border:1px solid var(--border);border-radius:16px;padding:12px;display:grid;grid-template-columns:auto 1fr auto;gap:12px;align-items:start;background:#fff}
 .task input[type="checkbox"]{margin-top:4px;transform:scale(1.35);accent-color:var(--accent2);cursor:pointer}
 .task label{font-weight:700;display:block}
-.desc{color:var(--muted);font-size:13px;margin-top:4px}
-.note{margin-top:10px;width:100%;border:1px solid var(--border);padding:10px 12px;border-radius:10px;font-size:13px}
+.desc{color:var(--muted);font-size:13px;margin-top:4px;word-break:break-word;overflow-wrap:anywhere}
+.note{margin-top:10px;width:100%;border:1px solid var(--border);padding:10px 12px;border-radius:10px;font-size:13px;word-break:break-word;overflow-wrap:anywhere}
 .del{border:1px solid #fecaca;background:#fee2e2;color:#b91c1c}
 .badge{display:inline-block;font-size:11px;font-weight:700;color:#065f46;background:#d1fae5;border:1px solid #a7f3d0;padding:3px 8px;border-radius:999px;margin-left:6px}
 .notesWrap{padding:0 28px 28px 28px;display:grid;grid-template-columns:1fr 1fr;gap:16px}
@@ -57,6 +57,7 @@ footer{padding:14px 28px 28px 28px;color:var(--muted);font-size:12px}
   .meta{grid-template-columns:1fr 1fr}
   .addForm{grid-template-columns:1fr}
   .notesWrap{grid-template-columns:1fr}
+  .filters{grid-template-columns:1fr 1fr}
   .toolbarButtons{display:none;flex-direction:column;position:absolute;top:100%;right:0;background:#fff;padding:10px;border:1px solid var(--border);border-radius:12px;gap:10px}
   .toolbar.open .toolbarButtons{display:flex}
   .menuBtn{display:block}
@@ -66,6 +67,7 @@ footer{padding:14px 28px 28px 28px;color:var(--muted);font-size:12px}
   .meta{grid-template-columns:1fr}
   ul.tasks{grid-template-columns:1fr}
   .notesWrap{grid-template-columns:1fr}
+  .filters{grid-template-columns:1fr}
 }
 @media (min-width:1024px){
   .page{max-width:1100px}
@@ -84,7 +86,7 @@ footer{padding:14px 28px 28px 28px;color:var(--muted);font-size:12px}
 }
 /* Filters bar */
 .filters{padding:0 28px 12px;display:grid;grid-template-columns:2fr 1.4fr 1.2fr auto;gap:10px}
-.filters input,.filters select{border:1px solid var(--border);border-radius:12px;padding:10px;background:#fff}
+.filters input,.filters select{border:1px solid var(--border);border-radius:12px;padding:10px;background:#fff;width:100%}
 .filters .onlyPending{display:flex;align-items:center;gap:8px}
 
 /* Tag chips & priority badges */
@@ -127,8 +129,8 @@ ul.tasks { gap: 14px; padding: 10px 18px 28px 18px; }
 .task .content{ display: grid; row-gap: 6px; }
 .task .content .titleRow{ display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
 .task .content label{ font-weight: 800; font-size: 15px; display: inline; }
-.task .desc{ color:#64748b; font-size: 13px; margin: 0; }
-.task .note{ margin-top: 4px; font-size: 13px; }
+.task .desc{ color:#64748b; font-size: 13px; margin: 0; word-break:break-word; overflow-wrap:anywhere; }
+.task .note{ margin-top: 4px; font-size: 13px; word-break:break-word; overflow-wrap:anywhere; }
 
 .task .actions{ display:flex; align-items:center; justify-content:flex-end; align-self:flex-start; }
 .task .del{


### PR DESCRIPTION
## Summary
- Improve grid layout of filter toolbar on narrow screens
- Prevent task descriptions and notes from overflowing by breaking long words
- Ensure form fields expand to full width on small devices

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2549f7c288322a79ee87fd063dc0b