### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,8 +1,8 @@
 :root { --bg:#f6f7fb; --card:#fff; --ink:#0f172a; --muted:#475569; --accent:#2563eb; --accent2:#10b981; --border:#e2e8f0; --shadow:0 10px 30px rgba(2,6,23,.08); }
 *{box-sizing:border-box}
 body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Apple Color Emoji","Segoe UI Emoji";color:var(--ink);background:linear-gradient(180deg,#f8fafc 0%,#eef2ff 100%)}
-.page{max-width:980px;margin:40px auto;padding:24px}
-.card{background:var(--card);border:1px solid var(--border);border-radius:20px;box-shadow:var(--shadow);overflow:hidden}
+.page{max-width:980px;margin:40px auto;padding:24px;width:100%}
+.card{background:var(--card);border:1px solid var(--border);border-radius:20px;box-shadow:var(--shadow);overflow:visible;width:100%}
 header{padding:28px 28px 10px 28px;display:grid;grid-template-columns:1fr auto;gap:16px;align-items:start}
 .title{font-size:28px;font-weight:800;letter-spacing:.2px}
 .subtitle{margin-top:6px;color:var(--muted);font-size:14px}
@@ -15,7 +15,7 @@ button.success{background:var(--accent2);color:#fff;border-color:var(--accent2)}
 button.danger{background:#ef4444;color:#fff;border-color:#ef4444}
 button:active{transform:translateY(1px)}
 .meta{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;padding:0 28px 18px 28px}
-.meta .field{background:#f8fafc;border:1px solid var(--border);border-radius:12px;padding:10px 12px}
+.meta .field{background:#f8fafc;border:1px solid var(--border);border-radius:12px;padding:10px 12px;min-width:0}
 .meta label{display:block;font-size:12px;color:var(--muted);margin-bottom:6px}
 .meta input{width:100%;border:none;outline:none;background:transparent;font-weight:600}
 .progressWrap{padding:10px 28px 2px 28px}
@@ -38,34 +38,39 @@ button:active{transform:translateY(1px)}
 #notesPanel[open] .notesSummary::after{content:'▲';}
 .notesHeader button{border:none;background:none;font-size:18px;cursor:pointer;line-height:1;padding:0;}
 
-.addForm{display:grid;grid-template-columns:1.2fr 2fr auto;gap:10px;padding:0 28px 12px}
-.addForm input,.addForm textarea{border:1px solid var(--border);border-radius:12px;padding:10px}
+.addForm{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:10px;padding:0 28px 12px}
+.addForm input,.addForm textarea{border:1px solid var(--border);border-radius:12px;padding:10px;min-width:0}
 .addForm .dateInputs{display:grid;grid-template-columns:1fr 1fr;gap:8px;width:100%}
 .addForm .dateInputs input{ text-align:center; }
 ul.tasks{list-style:none;margin:0;padding:8px 18px 24px 18px;display:grid;gap:10px}
-.task{border:1px solid var(--border);border-radius:16px;padding:12px;display:grid;grid-template-columns:auto 1fr auto;gap:12px;align-items:start;background:#fff}
+.task{border:1px solid var(--border);border-radius:16px;padding:12px;display:grid;grid-template-columns:26px 28px minmax(0,1fr) auto;gap:12px;align-items:start;background:#fff}
 .task input[type="checkbox"]{margin-top:4px;transform:scale(1.35);accent-color:var(--accent2);cursor:pointer}
 .task label{font-weight:700;display:block}
 .desc{color:var(--muted);font-size:13px;margin-top:4px}
-.note{margin-top:10px;width:100%;border:1px solid var(--border);padding:10px 12px;border-radius:10px;font-size:13px}
+.note{margin-top:10px;width:100%;border:1px solid var(--border);padding:10px 12px;border-radius:10px;font-size:13px;word-break:break-word;overflow-wrap:anywhere}
 .del{border:1px solid #fecaca;background:#fee2e2;color:#b91c1c}
 .badge{display:inline-block;font-size:11px;font-weight:700;color:#065f46;background:#d1fae5;border:1px solid #a7f3d0;padding:3px 8px;border-radius:999px;margin-left:6px}
 .notesWrap{padding:0 28px 28px 28px;display:grid;grid-template-columns:1fr 1fr;gap:16px}
-.notesWrap textarea{width:100%;min-height:150px;border:1px solid var(--border);border-radius:12px;padding:12px}
+.notesWrap textarea{width:100%;min-height:150px;border:1px solid var(--border);border-radius:12px;padding:12px;min-width:0}
 footer{padding:14px 28px 28px 28px;color:var(--muted);font-size:12px}
 @media (max-width:768px){
   .meta{grid-template-columns:1fr 1fr}
   .addForm{grid-template-columns:1fr}
   .notesWrap{grid-template-columns:1fr}
+  .filters{grid-template-columns:1fr 1fr}
   .toolbarButtons{display:none;flex-direction:column;position:absolute;top:100%;right:0;background:#fff;padding:10px;border:1px solid var(--border);border-radius:12px;gap:10px}
   .toolbar.open .toolbarButtons{display:flex}
   .menuBtn{display:block}
 }
 @media (max-width:480px){
+  .page{padding:12px}
   header{grid-template-columns:1fr auto}
-  .meta{grid-template-columns:1fr}
+  .meta{grid-template-columns:1fr;padding:0 12px 18px}
   ul.tasks{grid-template-columns:1fr}
-  .notesWrap{grid-template-columns:1fr}
+  .notesWrap{grid-template-columns:1fr;padding:0 12px 28px}
+  .filters{grid-template-columns:1fr;padding:0 12px 12px}
+  .addForm{grid-template-columns:1fr;padding:0 12px 12px}
+  .task{grid-template-columns:26px minmax(0,1fr) auto;gap:8px;padding:10px}
 }
 @media (min-width:1024px){
   .page{max-width:1100px}
@@ -83,9 +88,9 @@ footer{padding:14px 28px 28px 28px;color:var(--muted);font-size:12px}
   .task input[type="checkbox"]{transform:none;margin-top:0}
 }
 /* Filters bar */
-.filters{padding:0 28px 12px;display:grid;grid-template-columns:2fr 1.4fr 1.2fr auto;gap:10px}
-.filters input,.filters select{border:1px solid var(--border);border-radius:12px;padding:10px;background:#fff}
-.filters .onlyPending{display:flex;align-items:center;gap:8px}
+.filters{padding:0 28px 12px;display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:10px}
+.filters input,.filters select{border:1px solid var(--border);border-radius:12px;padding:10px;background:#fff;width:100%;min-width:0}
+.filters .onlyPending{display:flex;align-items:center;gap:8px;min-width:0}
 
 /* Tag chips & priority badges */
 .chips{margin-top:6px;display:flex;gap:6px;flex-wrap:wrap}
@@ -101,18 +106,18 @@ footer{padding:14px 28px 28px 28px;color:var(--muted);font-size:12px}
 /* ===== Task Card Redesign ===== */
 ul.tasks { gap: 14px; padding: 10px 18px 28px 18px; }
 
-.task{
-  display: grid;
-  grid-template-columns: 26px 28px 1fr 36px; /* handle | checkbox | content | actions */
-  align-items: center;
-  gap: 12px;
-  padding: 12px 12px;
-  background: #fff;
-  border: 1px solid var(--border);
-  border-radius: 16px;
-  box-shadow: var(--shadow);
-  transition: transform .12s ease, box-shadow .12s ease, border-color .12s ease, background-color .12s ease;
-}
+  .task{
+    display: grid;
+    grid-template-columns: 26px 28px minmax(0,1fr) auto; /* handle | checkbox | content | actions */
+    align-items: center;
+    gap: 12px;
+    padding: 12px 12px;
+    background: #fff;
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    box-shadow: var(--shadow);
+    transition: transform .12s ease, box-shadow .12s ease, border-color .12s ease, background-color .12s ease;
+  }
 .task:hover{ transform: translateY(-1px); border-color:#d1d5db; box-shadow: 0 10px 24px rgba(2,6,23,.10); }
 
 .task .handle{
@@ -124,7 +129,7 @@ ul.tasks { gap: 14px; padding: 10px 18px 28px 18px; }
 
 .task input[type="checkbox"]{ margin: 0 auto; transform: scale(1.25); accent-color: var(--accent2); }
 
-.task .content{ display: grid; row-gap: 6px; }
+.task .content{ display: grid; row-gap: 6px; min-width:0; }
 .task .content .titleRow{ display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
 .task .content label{ font-weight: 800; font-size: 15px; display: inline; }
 .task .desc{ color:#64748b; font-size: 13px; margin: 0; }
@@ -155,7 +160,7 @@ ul.tasks { gap: 14px; padding: 10px 18px 28px 18px; }
 .task .dates .due{ color:var(--accent); font-weight:600; }
 
 /* Actions */
-.task{ grid-template-columns: 26px 28px 1fr 76px; }
+.task{ grid-template-columns: 26px 28px minmax(0,1fr) auto; }
 .actions{ display:flex; gap:8px; justify-content:flex-end; align-items:center; }
 .actions .edit{
   border: 1px solid var(--border); background: transparent; color:#0f172a;


### PR DESCRIPTION
## Summary
- Make form and filter sections flexibly wrap to available width
- Allow task content and notes to shrink and wrap to avoid clipping
- Tune mobile padding and task layout for small screens

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2549f7c288322a79ee87fd063dc0b