### PR TITLE
Add sidebar and responsive grid layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -103,7 +103,13 @@ footer{padding:14px 28px 28px 28px;color:var(--muted);font-size:12px}
 /* Desktop wide */
 @media (min-width:1024px){
   .page{max-width:1100px}
+  .card{display:grid;grid-template-columns:2fr 1fr;}
+  .card>header{grid-column:1/-1}
   .filters, .addForm{grid-template-columns:repeat(auto-fit,minmax(220px,1fr));}
+}
+
+@media (max-width:1023px){
+  .card{display:block}
 }
 
 /* Print */

--- a/index.php
+++ b/index.php
@@ -29,73 +29,77 @@
         </div>
       </header>
 
-      <div class="meta">
-        <div class="field"><label>Ημερομηνία</label><input id="dateField" placeholder="π.χ. 14/08/2025"></div>
-        <div class="field"><label>Υπεύθυνος</label><input id="ownerField" placeholder="π.χ. Γιώργος"></div>
-        <div class="field"><label>Τηλ. Επικοινωνίας</label><input id="phoneField" placeholder=""></div>
-        <div class="field"><label>Συνολική Πρόοδος</label><input id="progressField" readonly></div>
-      </div>
-
-      <div class="progressWrap">
-        <div class="progressLabel"><span>Πρόοδος εργασιών</span><span id="percentText">0%</span></div>
-        <div class="progress"><div class="bar" id="bar"></div></div>
-      </div>
-      
-      <div class="sectionTitle">Φίλτρα</div>
-      <div class="filters">
-        <input id="filterSearch" placeholder="Αναζήτηση τίτλου/περιγραφής">
-        <input id="filterTag" placeholder="Ετικέτα (π.χ. Ηλεκτρικά)">
-        <select id="filterPriority">
-          <option value="">Προτεραιότητα: Όλες</option>
-          <option value="1">Υψηλή</option>
-          <option value="2">Μεσαία</option>
-          <option value="3">Χαμηλή</option>
-        </select>
-        <input type="date" id="filterFrom" title="Από" placeholder="Από">
-        <input type="date" id="filterTo" title="Μέχρι" placeholder="Μέχρι">
-        <select id="sortDate">
-          <option value="">Ταξινόμηση: Καμία</option>
-          <option value="start_asc">Από ↑</option>
-          <option value="start_desc">Από ↓</option>
-          <option value="due_asc">Μέχρι ↑</option>
-          <option value="due_desc">Μέχρι ↓</option>
-        </select>
-        <label class="onlyPending"><input type="checkbox" id="filterPending"> Μόνο εκκρεμή</label>
-      </div>
-
-      <div class="sectionTitle">Προσθήκη νέας εργασίας</div>
-      <div class="addForm">
-        <input id="addTitle" placeholder="Τίτλος (π.χ. Βάψιμο υπνοδωματίου)">
-        <textarea id="addDesc" placeholder="Σύντομη περιγραφή"></textarea>
-        <select id="addPriority" title="Προτεραιότητα">
-          <option value="2" selected>Μεσαία</option>
-          <option value="1">Υψηλή</option>
-          <option value="3">Χαμηλή</option>
-        </select>
-        <input id="addTags" placeholder="Ετικέτες (π.χ. Ηλεκτρικά,Μπάνιο)">
-        <div class="dateInputs">
-          <input id="addStart" type="date" placeholder="Από" title="Ημερομηνία αρχής">
-          <input id="addDue" type="date" placeholder="Μέχρι" title="Ημερομηνία λήξης">
+      <main class="task-area">
+        <div class="meta">
+          <div class="field"><label>Ημερομηνία</label><input id="dateField" placeholder="π.χ. 14/08/2025"></div>
+          <div class="field"><label>Υπεύθυνος</label><input id="ownerField" placeholder="π.χ. Γιώργος"></div>
+          <div class="field"><label>Τηλ. Επικοινωνίας</label><input id="phoneField" placeholder=""></div>
+          <div class="field"><label>Συνολική Πρόοδος</label><input id="progressField" readonly></div>
         </div>
-        <button class="success" id="addBtn">+ Προσθήκη</button>
-      </div>
 
-      <div class="sectionTitle">Εργασίες</div>
-      <ul class="tasks" id="taskList"></ul>
+        <div class="progressWrap">
+          <div class="progressLabel"><span>Πρόοδος εργασιών</span><span id="percentText">0%</span></div>
+          <div class="progress"><div class="bar" id="bar"></div></div>
+        </div>
 
-      <!-- ✅ Notes section from main -->
-      <div class="sectionTitle notesHeader">
-        <span>Συνολικές Σημειώσεις</span>
-        <button id="notesToggle" aria-expanded="false">⮟</button>
-      </div>
-      <div class="notesWrap hidden" id="notesSection">
-        <textarea id="notes" placeholder="Γενικές παρατηρήσεις, ημερολόγιο εργασιών, εκκρεμότητες."></textarea>
-        <textarea id="materials" placeholder="Υλικά προς αγορά / παραγγελίες."></textarea>
-      </div>
+        <div class="sectionTitle">Εργασίες</div>
+        <ul class="tasks" id="taskList"></ul>
 
-      <footer>
-        Συμβουλή: Κάντε κλικ στο «Εκτύπωση / PDF» για να αποθηκεύσετε την τρέχουσα κατάσταση ως PDF.
-      </footer>
+        <!-- ✅ Notes section from main -->
+        <div class="sectionTitle notesHeader">
+          <span>Συνολικές Σημειώσεις</span>
+          <button id="notesToggle" aria-expanded="false">⮟</button>
+        </div>
+        <div class="notesWrap hidden" id="notesSection">
+          <textarea id="notes" placeholder="Γενικές παρατηρήσεις, ημερολόγιο εργασιών, εκκρεμότητες."></textarea>
+          <textarea id="materials" placeholder="Υλικά προς αγορά / παραγγελίες."></textarea>
+        </div>
+
+        <footer>
+          Συμβουλή: Κάντε κλικ στο «Εκτύπωση / PDF» για να αποθηκεύσετε την τρέχουσα κατάσταση ως PDF.
+        </footer>
+      </main>
+
+      <aside class="sidebar">
+        <div class="sectionTitle">Φίλτρα</div>
+        <div class="filters">
+          <input id="filterSearch" placeholder="Αναζήτηση τίτλου/περιγραφής">
+          <input id="filterTag" placeholder="Ετικέτα (π.χ. Ηλεκτρικά)">
+          <select id="filterPriority">
+            <option value="">Προτεραιότητα: Όλες</option>
+            <option value="1">Υψηλή</option>
+            <option value="2">Μεσαία</option>
+            <option value="3">Χαμηλή</option>
+          </select>
+          <input type="date" id="filterFrom" title="Από" placeholder="Από">
+          <input type="date" id="filterTo" title="Μέχρι" placeholder="Μέχρι">
+          <select id="sortDate">
+            <option value="">Ταξινόμηση: Καμία</option>
+            <option value="start_asc">Από ↑</option>
+            <option value="start_desc">Από ↓</option>
+            <option value="due_asc">Μέχρι ↑</option>
+            <option value="due_desc">Μέχρι ↓</option>
+          </select>
+          <label class="onlyPending"><input type="checkbox" id="filterPending"> Μόνο εκκρεμή</label>
+        </div>
+
+        <div class="sectionTitle">Προσθήκη νέας εργασίας</div>
+        <div class="addForm">
+          <input id="addTitle" placeholder="Τίτλος (π.χ. Βάψιμο υπνοδωματίου)">
+          <textarea id="addDesc" placeholder="Σύντομη περιγραφή"></textarea>
+          <select id="addPriority" title="Προτεραιότητα">
+            <option value="2" selected>Μεσαία</option>
+            <option value="1">Υψηλή</option>
+            <option value="3">Χαμηλή</option>
+          </select>
+          <input id="addTags" placeholder="Ετικέτες (π.χ. Ηλεκτρικά,Μπάνιο)">
+          <div class="dateInputs">
+            <input id="addStart" type="date" placeholder="Από" title="Ημερομηνία αρχής">
+            <input id="addDue" type="date" placeholder="Μέχρι" title="Ημερομηνία λήξης">
+          </div>
+          <button class="success" id="addBtn">+ Προσθήκη</button>
+        </div>
+      </aside>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- Wrap filter controls and task form in an `aside.sidebar` and task list in `main.task-area`
- Introduce desktop grid layout on `.card` (2fr/1fr) with header spanning both columns
- Revert to single-column card on small screens via media query

## Testing
- `php -l index.php`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a380a114a48322a3e1813c97e46188