### PR TITLE
Make progress bar sticky

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -20,7 +20,7 @@ button:active{transform:translateY(1px)}
 .meta .field{background:#f8fafc;border:1px solid var(--border);border-radius:12px;padding:10px 12px;min-width:0}
 .meta label{display:block;font-size:12px;color:var(--muted);margin-bottom:6px}
 .meta input{width:100%;border:none;outline:none;background:transparent;font-weight:600}
-.progressWrap{padding:10px 28px 2px 28px}
+.progressWrap{position:sticky;top:0;z-index:20;padding:10px 28px 2px 28px;background:var(--card);box-shadow:var(--shadow)}
 .progressLabel{display:flex;justify-content:space-between;font-size:12px;color:var(--muted);margin-bottom:6px}
 .progress{height:12px;background:#eef2ff;border:1px solid var(--border);border-radius:999px;overflow:hidden;position:relative}
 .bar{height:100%;width:0%;background:linear-gradient(90deg,var(--accent),var(--accent2));transition:width .25s ease}


### PR DESCRIPTION
## Summary
- make progress bar sticky so it stays visible at top
- ensure container allows progress bar shadow to display

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a381deb62c8322b6ee393786af1be1