### PR TITLE
feat: add mobile fab modal for tasks

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -113,6 +113,10 @@ ul.tasks{list-style:none;margin:0;padding:8px 18px 24px 18px;display:grid;gap:10
 .notesWrap textarea{width:100%;min-height:150px;border:1px solid var(--border);border-radius:12px;padding:12px;min-width:0}
 footer{padding:14px 28px 28px 28px;color:var(--muted);font-size:12px}
 
+button.fab{display:none;width:56px;height:56px;border-radius:50%;background:var(--accent);color:#fff;border:none;font-size:32px;line-height:1;box-shadow:var(--shadow);justify-content:center;align-items:center}
+#addModal .box{width:90%;max-width:500px}
+#addModal .addForm{padding:0;grid-template-columns:1fr}
+
 /* Mobile */
 @media (max-width:768px){
   .meta{grid-template-columns:1fr 1fr}
@@ -130,7 +134,8 @@ footer{padding:14px 28px 28px 28px;color:var(--muted);font-size:12px}
   ul.tasks{grid-template-columns:1fr}
   .notesWrap{grid-template-columns:1fr;padding:0 12px 28px}
   .filters{grid-template-columns:1fr;padding:0 12px 12px}
-  .addForm{grid-template-columns:1fr;padding:0 12px 12px}
+  #addSectionTitle,.sidebar .addForm{display:none}
+  .fab{display:flex;position:fixed;bottom:20px;right:20px}
   .tagPrio{grid-template-columns:1fr}
   .editForm .dateInputs{grid-template-columns:1fr}
   .addForm .dateInputs{grid-template-columns:1fr}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,5 +1,6 @@
 import { init } from './tasks.js';
 import './filters.js';
+import { el } from './api.js';
 
 function setupThemeToggle() {
   const toggle = document.getElementById('themeToggle');
@@ -26,4 +27,29 @@ function setupThemeToggle() {
 document.addEventListener('DOMContentLoaded', () => {
   setupThemeToggle();
   init();
+  setupAddModal();
 });
+
+function setupAddModal(){
+  const fab = el('#fabBtn');
+  const modal = el('#addModal');
+  const cancel = el('#modalCancel');
+  const save = el('#modalSave');
+  if (!fab || !modal) return;
+  const show = () => modal.classList.remove('hidden');
+  const hide = () => modal.classList.add('hidden');
+  fab.addEventListener('click', show);
+  cancel?.addEventListener('click', hide);
+  save?.addEventListener('click', () => {
+    ['Title','Desc','Priority','Tags','Start','Due'].forEach(f => {
+      const src = el('#modal' + f);
+      const dst = el('#add' + f);
+      if (src && dst) dst.value = src.value;
+    });
+    el('#addBtn')?.click();
+    hide();
+    ['Title','Desc','Priority','Tags','Start','Due'].forEach(f => {
+      const src = el('#modal' + f); if (src) src.value = '';
+    });
+  });
+}

--- a/index.php
+++ b/index.php
@@ -87,7 +87,7 @@
           <label class="onlyPending"><input type="checkbox" id="filterPending"> Μόνο εκκρεμή</label>
         </div>
 
-        <div class="sectionTitle">Προσθήκη νέας εργασίας</div>
+        <div class="sectionTitle" id="addSectionTitle">Προσθήκη νέας εργασίας</div>
         <div class="addForm">
           <input id="addTitle" placeholder="Τίτλος (π.χ. Βάψιμο υπνοδωματίου)">
           <textarea id="addDesc" placeholder="Σύντομη περιγραφή"></textarea>
@@ -107,12 +107,37 @@
     </div>
   </div>
 
+  <button class="fab" id="fabBtn">+</button>
+
   <div id="confirmModal" class="modal hidden">
     <div class="box">
       <p id="confirmText">Να διαγραφούν όλες οι εργασίες; Η ενέργεια δεν αναιρείται.</p>
       <div class="actions">
         <button id="confirmYes" class="danger">Διαγραφή</button>
         <button id="confirmNo">Άκυρο</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="addModal" class="modal hidden">
+    <div class="box">
+      <div class="addForm">
+        <input id="modalTitle" placeholder="Τίτλος (π.χ. Βάψιμο υπνοδωματίου)">
+        <textarea id="modalDesc" placeholder="Σύντομη περιγραφή"></textarea>
+        <select id="modalPriority" title="Προτεραιότητα">
+          <option value="2" selected>Μεσαία</option>
+          <option value="1">Υψηλή</option>
+          <option value="3">Χαμηλή</option>
+        </select>
+        <input id="modalTags" placeholder="Ετικέτες (π.χ. Ηλεκτρικά,Μπάνιο)">
+        <div class="dateInputs">
+          <input id="modalStart" type="date" placeholder="Από" title="Ημερομηνία αρχής">
+          <input id="modalDue" type="date" placeholder="Μέχρι" title="Ημερομηνία λήξης">
+        </div>
+      </div>
+      <div class="actions">
+        <button id="modalSave" class="success">Αποθήκευση</button>
+        <button id="modalCancel">Άκυρο</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- hide sidebar add form on small screens and add floating action button
- create modal form for adding tasks
- wire modal actions to existing add logic

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a38e5536248322949cba069e8df38d