### PR TITLE
Add mobile filters side panel

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -117,6 +117,15 @@ button.fab{display:none;width:56px;height:56px;border-radius:50%;background:var(
 #addModal .box{width:90%;max-width:500px}
 #addModal .addForm{padding:0;grid-template-columns:1fr}
 
+/* Filters side panel */
+.filters-panel{position:fixed;inset:0;background:rgba(0,0,0,.4);transform:translateX(100%);transition:transform .3s ease;display:flex;justify-content:flex-end;pointer-events:none;z-index:1000}
+.filters-panel .panel{width:80%;max-width:360px;background:var(--card);padding:20px;height:100%;overflow:auto;box-shadow:var(--shadow)}
+.filters-panel.open{transform:translateX(0);pointer-events:auto}
+@media (min-width:769px){
+  .filters-panel{position:static;transform:none;background:none;display:block;pointer-events:auto;transition:none}
+  .filters-panel .panel{width:auto;max-width:none;padding:0;height:auto;box-shadow:none}
+}
+
 /* Mobile */
 @media (max-width:768px){
   .meta{grid-template-columns:1fr 1fr}

--- a/assets/js/tasks.js
+++ b/assets/js/tasks.js
@@ -242,6 +242,23 @@ export function init(){
     });
   }
 
+  const filtersBtn = el('#filtersBtn');
+  const filtersPanel = el('#filtersPanel');
+  if (filtersBtn && filtersPanel) {
+    const closePanel = () => filtersPanel.classList.remove('open');
+    filtersBtn.addEventListener('click', () => {
+      filtersPanel.classList.toggle('open');
+    });
+    filtersPanel.addEventListener('click', (e) => {
+      if (e.target === filtersPanel) closePanel();
+    });
+    let startX = 0;
+    filtersPanel.addEventListener('touchstart', e => { startX = e.touches[0].clientX; });
+    filtersPanel.addEventListener('touchend', e => {
+      if (e.changedTouches[0].clientX - startX > 50) closePanel();
+    });
+  }
+
   el('#printBtn')?.addEventListener('click', () => {
     window.open(`print.php?list_id=${LIST_ID}`, '_blank');
   });

--- a/index.php
+++ b/index.php
@@ -25,6 +25,7 @@
             <span class="slider"></span>
           </label>
           <button class="menuBtn" id="menuBtn">☰</button>
+          <button class="menuBtn" id="filtersBtn">Φίλτρα</button>
           <div class="toolbarButtons">
             <button class="primary" id="printBtn">🖨️ Εκτύπωση / PDF</button>
             <button id="resetBtn">↺ Επαναφορά επιλογών</button>
@@ -64,46 +65,50 @@
         </footer>
       </main>
 
-      <aside class="sidebar">
-        <div class="sectionTitle">Φίλτρα</div>
-        <div class="filters">
-          <input id="filterSearch" placeholder="Αναζήτηση τίτλου/περιγραφής">
-          <input id="filterTag" placeholder="Ετικέτα (π.χ. Ηλεκτρικά)">
-          <select id="filterPriority">
-            <option value="">Προτεραιότητα: Όλες</option>
-            <option value="1">Υψηλή</option>
-            <option value="2">Μεσαία</option>
-            <option value="3">Χαμηλή</option>
-          </select>
-          <input type="date" id="filterFrom" title="Από" placeholder="Από">
-          <input type="date" id="filterTo" title="Μέχρι" placeholder="Μέχρι">
-          <select id="sortDate">
-            <option value="">Ταξινόμηση: Καμία</option>
-            <option value="start_asc">Από ↑</option>
-            <option value="start_desc">Από ↓</option>
-            <option value="due_asc">Μέχρι ↑</option>
-            <option value="due_desc">Μέχρι ↓</option>
-          </select>
-          <label class="onlyPending"><input type="checkbox" id="filterPending"> Μόνο εκκρεμή</label>
-        </div>
-
-        <div class="sectionTitle" id="addSectionTitle">Προσθήκη νέας εργασίας</div>
-        <div class="addForm">
-          <input id="addTitle" placeholder="Τίτλος (π.χ. Βάψιμο υπνοδωματίου)">
-          <textarea id="addDesc" placeholder="Σύντομη περιγραφή"></textarea>
-          <select id="addPriority" title="Προτεραιότητα">
-            <option value="2" selected>Μεσαία</option>
-            <option value="1">Υψηλή</option>
-            <option value="3">Χαμηλή</option>
-          </select>
-          <input id="addTags" placeholder="Ετικέτες (π.χ. Ηλεκτρικά,Μπάνιο)">
-          <div class="dateInputs">
-            <input id="addStart" type="date" placeholder="Από" title="Ημερομηνία αρχής">
-            <input id="addDue" type="date" placeholder="Μέχρι" title="Ημερομηνία λήξης">
+    <aside class="sidebar">
+      <div id="filtersPanel" class="filters-panel">
+        <div class="panel">
+          <div class="sectionTitle">Φίλτρα</div>
+          <div class="filters">
+            <input id="filterSearch" placeholder="Αναζήτηση τίτλου/περιγραφής">
+            <input id="filterTag" placeholder="Ετικέτα (π.χ. Ηλεκτρικά)">
+            <select id="filterPriority">
+              <option value="">Προτεραιότητα: Όλες</option>
+              <option value="1">Υψηλή</option>
+              <option value="2">Μεσαία</option>
+              <option value="3">Χαμηλή</option>
+            </select>
+            <input type="date" id="filterFrom" title="Από" placeholder="Από">
+            <input type="date" id="filterTo" title="Μέχρι" placeholder="Μέχρι">
+            <select id="sortDate">
+              <option value="">Ταξινόμηση: Καμία</option>
+              <option value="start_asc">Από ↑</option>
+              <option value="start_desc">Από ↓</option>
+              <option value="due_asc">Μέχρι ↑</option>
+              <option value="due_desc">Μέχρι ↓</option>
+            </select>
+            <label class="onlyPending"><input type="checkbox" id="filterPending"> Μόνο εκκρεμή</label>
           </div>
-          <button class="success" id="addBtn">+ Προσθήκη</button>
         </div>
-      </aside>
+      </div>
+
+      <div class="sectionTitle" id="addSectionTitle">Προσθήκη νέας εργασίας</div>
+      <div class="addForm">
+        <input id="addTitle" placeholder="Τίτλος (π.χ. Βάψιμο υπνοδωματίου)">
+        <textarea id="addDesc" placeholder="Σύντομη περιγραφή"></textarea>
+        <select id="addPriority" title="Προτεραιότητα">
+          <option value="2" selected>Μεσαία</option>
+          <option value="1">Υψηλή</option>
+          <option value="3">Χαμηλή</option>
+        </select>
+        <input id="addTags" placeholder="Ετικέτες (π.χ. Ηλεκτρικά,Μπάνιο)">
+        <div class="dateInputs">
+          <input id="addStart" type="date" placeholder="Από" title="Ημερομηνία αρχής">
+          <input id="addDue" type="date" placeholder="Μέχρι" title="Ημερομηνία λήξης">
+        </div>
+        <button class="success" id="addBtn">+ Προσθήκη</button>
+      </div>
+    </aside>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- Add "Φίλτρα" button to toolbar for mobile
- Introduce responsive filters side panel with overlay and swipe-to-close
- Hide inline filters on small screens and adjust styles

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a39b5aaa98832290c9d9069f462072