### PR TITLE
Expand page width on large screens

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -53,7 +53,7 @@ body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Aria
 input,textarea,select{color:var(--ink)}
 body.editing-open{overflow:hidden;}
 
-.page{max-width:980px;margin:40px auto;padding:24px;width:100%}
+.page{max-width:1280px;margin:40px auto;padding:24px;width:100%}
 .card{background:var(--card);border:1px solid var(--border);border-radius:20px;box-shadow:var(--shadow);overflow:visible;width:100%}
 header{padding:28px 28px 10px 28px;display:grid;grid-template-columns:1fr auto;gap:16px;align-items:start}
 .title{font-size:28px;font-weight:800;letter-spacing:.2px}
@@ -177,7 +177,7 @@ button.fab{display:none;width:56px;height:56px;border-radius:50%;background:var(
 
 /* Desktop wide */
 @media (min-width:1024px){
-  .page{max-width:1100px}
+  .page{max-width:1280px}
   .card{display:grid;grid-template-columns:2fr 1fr;}
   .card>header{grid-column:1/-1}
   .filters, .addForm{grid-template-columns:repeat(auto-fit,minmax(220px,1fr));}


### PR DESCRIPTION
## Summary
- widen main page container to use up to 1280px
- adjust desktop media query for new width

## Testing
- `npm run build`
- `npm run dev` (startup only)


------
https://chatgpt.com/codex/tasks/task_e_68a4e2c53bcc8322beb65a7a5594ad39