### PR TITLE
Add animated transitions for task notes

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -296,12 +296,19 @@ ul.tasks { gap: 14px; padding: 10px 18px 28px 18px; }
 .editBtns{ display:flex; gap:8px; justify-content:flex-end; }
 
 /* Notes thread */
-.taskNotes{ margin-top:6px; }
+.taskNotes{ margin-top:6px; overflow:hidden; }
 .taskNotes summary{ cursor:pointer; display:flex; align-items:center; justify-content:space-between; font-weight:600; }
 .taskNotes summary::-webkit-details-marker{ display:none; }
 .taskNotes summary::marker{ content:""; }
 .taskNotes summary::after{ content:'▼'; font-size:14px; transition:transform .2s; }
 .taskNotes[open] summary::after{ transform:rotate(180deg); }
+
+/* Smooth expand/collapse for notes */
+.taskNotes .addNote,
+.taskNotes .notesThread{ max-height:0; opacity:0; overflow:hidden; transition:max-height .25s ease, opacity .25s ease; }
+.taskNotes.opening .addNote,
+.taskNotes.opening .notesThread{ max-height:500px; opacity:1; }
+
 .addNote{ margin-top:6px; display:flex; gap:8px; }
 
 .modal{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;animation:fadeIn .25s;z-index:200;}

--- a/assets/js/notes.js
+++ b/assets/js/notes.js
@@ -22,6 +22,7 @@ export function initNotes(li, task){
   const thread  = el('.notesThread', li);
   const wrapper = el('.taskNotes', li);      // <details>
   const noteInput = el('.noteText', li);     // ✅ Codex change
+  const summary = el('summary', wrapper);
 
   const ensureLoaded = async () => {
     if (thread.dataset.loaded === '1') return;
@@ -40,8 +41,24 @@ export function initNotes(li, task){
   // Όταν ανοίγει το <details>, φόρτωσε & εστίασε στο input
   wrapper?.addEventListener('toggle', () => {
     if (wrapper.open){
+      wrapper.classList.add('opening');
       ensureLoaded();
       noteInput?.focus();
+    } else {
+      wrapper.classList.remove('opening');
+    }
+  });
+
+  // Απαλή κατάρρευση όταν κλείνει
+  summary?.addEventListener('click', (e) => {
+    if (wrapper.open){
+      e.preventDefault();
+      wrapper.classList.remove('opening');
+      const onEnd = () => {
+        wrapper.open = false;
+      };
+      const target = el('.notesThread', wrapper);
+      target?.addEventListener('transitionend', onEnd, { once:true });
     }
   });
 


### PR DESCRIPTION
## Summary
- animate task note sections using max-height/opacity transitions
- toggle `opening` class on note details to drive animation and handle smooth closing

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4e44da0a883228e6ff7d5a252f1f1