### PR TITLE
feat: add transitions for edit mode

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -285,8 +285,31 @@ ul.tasks { gap: 14px; padding: 10px 18px 28px 18px; }
 
 /* Edit form */
 .hidden{ display:none !important; }
-.task .editForm{ display:none; border:1px dashed var(--border); background:var(--card); padding:10px; border-radius:12px; margin-top:6px; }
-.task.editing .editForm{ display:block; }
+
+/* Generic fade helpers */
+.fade{ transition:opacity .2s ease, transform .2s ease; }
+.fade.fade-out{ opacity:0; transform:translateY(-4px); }
+
+.task .editForm{
+  border:1px dashed var(--border);
+  background:var(--card);
+  border-radius:12px;
+  overflow:hidden;
+  max-height:0;
+  opacity:0;
+  transform:scale(.98);
+  margin-top:0;
+  padding:0 10px;
+  transition:max-height .2s ease, opacity .2s ease, transform .2s ease, margin-top .2s ease, padding .2s ease;
+}
+
+.task .editForm.open{
+  max-height:1000px;
+  opacity:1;
+  transform:scale(1);
+  margin-top:6px;
+  padding:10px;
+}
 .editForm .row{ display:grid; grid-template-columns:1fr; gap:8px; }
 .editForm input, .editForm textarea, .editForm select{ border:1px solid var(--border); border-radius:10px; padding:10px; width:100%; }
 .editForm select{-webkit-appearance:none;appearance:none;padding-right:32px;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%23677389' d='M5 6L0 0h10z'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 12px center;background-size:10px}

--- a/assets/js/tasks.js
+++ b/assets/js/tasks.js
@@ -29,6 +29,28 @@ function renderDates(start, due){
   return '';
 }
 
+function hideWithFade(el){
+  if (!el) return;
+  el.classList.add('fade');
+  requestAnimationFrame(() => el.classList.add('fade-out'));
+  el.addEventListener('transitionend', function handler(){
+    el.classList.add('hidden');
+    el.classList.remove('fade', 'fade-out');
+    el.removeEventListener('transitionend', handler);
+  }, { once:true });
+}
+
+function showWithFade(el){
+  if (!el) return;
+  el.classList.remove('hidden');
+  el.classList.add('fade', 'fade-out');
+  requestAnimationFrame(() => el.classList.remove('fade-out'));
+  el.addEventListener('transitionend', function handler(){
+    el.classList.remove('fade');
+    el.removeEventListener('transitionend', handler);
+  }, { once:true });
+}
+
 export function taskItem(t){
   const li = document.createElement('li');
   li.className = 'task';
@@ -108,17 +130,19 @@ export function taskItem(t){
   const content = el('.content', li);
 
   el('.edit', li).addEventListener('click', () => {
-    content.querySelector('.titleRow').classList.add('hidden');
-    content.querySelector('.desc').classList.add('hidden');
-    const chips = content.querySelector('.chips'); if (chips) chips.classList.add('hidden');
+    hideWithFade(content.querySelector('.titleRow'));
+    hideWithFade(content.querySelector('.desc'));
+    const chips = content.querySelector('.chips'); if (chips) hideWithFade(chips);
+    el('.editForm', li).classList.add('open');
     li.classList.add('editing');
     document.body.classList.add('editing-open');
   });
 
   el('.cancelEdit', li).addEventListener('click', () => {
-    content.querySelector('.titleRow').classList.remove('hidden');
-    content.querySelector('.desc').classList.remove('hidden');
-    const chips = content.querySelector('.chips'); if (chips) chips.classList.remove('hidden');
+    showWithFade(content.querySelector('.titleRow'));
+    showWithFade(content.querySelector('.desc'));
+    const chips = content.querySelector('.chips'); if (chips) showWithFade(chips);
+    el('.editForm', li).classList.remove('open');
     li.classList.remove('editing');
     document.body.classList.remove('editing-open');
   });


### PR DESCRIPTION
## Summary
- animate task edit form with opacity/transform transitions
- fade task details in/out when toggling edit mode

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a4e59a4bcc8322b0327eb534f805b3