### PR TITLE
Support datetime for task dates

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -59,10 +59,19 @@ function ensure_task_enhancements(PDO $pdo): void {
 }
 
 function ensure_task_dates(PDO $pdo): void {
-  try { $pdo->query('SELECT start_date FROM tasks LIMIT 1'); }
-  catch (Throwable $e) { $pdo->exec("ALTER TABLE tasks ADD COLUMN start_date DATE NULL AFTER tags"); }
-  try { $pdo->query('SELECT due_date FROM tasks LIMIT 1'); }
-  catch (Throwable $e) { $pdo->exec("ALTER TABLE tasks ADD COLUMN due_date DATE NULL AFTER start_date"); }
+  $col = $pdo->query("SHOW COLUMNS FROM tasks LIKE 'start_date'")->fetch(PDO::FETCH_ASSOC);
+  if (!$col) {
+    $pdo->exec("ALTER TABLE tasks ADD COLUMN start_date DATETIME NULL AFTER tags");
+  } elseif (stripos((string)$col['Type'], 'datetime') === false) {
+    $pdo->exec("ALTER TABLE tasks MODIFY start_date DATETIME NULL");
+  }
+
+  $col = $pdo->query("SHOW COLUMNS FROM tasks LIKE 'due_date'")->fetch(PDO::FETCH_ASSOC);
+  if (!$col) {
+    $pdo->exec("ALTER TABLE tasks ADD COLUMN due_date DATETIME NULL AFTER start_date");
+  } elseif (stripos((string)$col['Type'], 'datetime') === false) {
+    $pdo->exec("ALTER TABLE tasks MODIFY due_date DATETIME NULL");
+  }
 }
 
 function csrf_token(): string {

--- a/app/migrations/003_task_datetime.sql
+++ b/app/migrations/003_task_datetime.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tasks
+  MODIFY start_date DATETIME NULL,
+  MODIFY due_date   DATETIME NULL;

--- a/assets/js/tasks.js
+++ b/assets/js/tasks.js
@@ -8,7 +8,11 @@ let BOOT = null;
 
 function escapeHtml(s){ return (s||'').replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c])); }
 function escapeAttr(s){ return (s||'').replace(/"/g, '&quot;'); }
-const fmtDate = d => new Date(d).toLocaleDateString('el-GR', { day:'2-digit', month:'2-digit' });
+const fmtDate = d => {
+  if (!d) return '';
+  const dt = new Date(d);
+  return dt.toLocaleString('el-GR', { day:'2-digit', month:'2-digit', hour:'2-digit', minute:'2-digit' });
+};
 
 function prioBadge(p){
   const map = {1:'Υψηλή',2:'Μεσαία',3:'Χαμηλή'};
@@ -96,8 +100,8 @@ export function taskItem(t){
             </select>
           </div>
           <div class="dateInputs">
-            <input class="editStart" type="date" value="${escapeAttr(t.start_date || '')}" placeholder="Από" title="Ημερομηνία αρχής">
-            <input class="editDue" type="date"   value="${escapeAttr(t.due_date   || '')}" placeholder="Μέχρι" title="Ημερομηνία λήξης">
+            <input class="editStart" type="datetime-local" value="${escapeAttr(t.start_date || '')}" placeholder="Από" title="Ημερομηνία αρχής">
+            <input class="editDue" type="datetime-local"   value="${escapeAttr(t.due_date   || '')}" placeholder="Μέχρι" title="Ημερομηνία λήξης">
           </div>
           <div class="editBtns">
             <button class="saveEdit success">Αποθήκευση</button>

--- a/index.php
+++ b/index.php
@@ -78,8 +78,8 @@
               <option value="2">Μεσαία</option>
               <option value="3">Χαμηλή</option>
             </select>
-            <input type="date" id="filterFrom" title="Από" placeholder="Από">
-            <input type="date" id="filterTo" title="Μέχρι" placeholder="Μέχρι">
+            <input type="datetime-local" id="filterFrom" title="Από" placeholder="Από">
+            <input type="datetime-local" id="filterTo" title="Μέχρι" placeholder="Μέχρι">
             <select id="sortDate">
               <option value="">Ταξινόμηση: Καμία</option>
               <option value="start_asc">Από ↑</option>
@@ -103,8 +103,8 @@
         </select>
         <input id="addTags" placeholder="Ετικέτες (π.χ. Ηλεκτρικά,Μπάνιο)">
         <div class="dateInputs">
-          <input id="addStart" type="date" placeholder="Από" title="Ημερομηνία αρχής">
-          <input id="addDue" type="date" placeholder="Μέχρι" title="Ημερομηνία λήξης">
+          <input id="addStart" type="datetime-local" placeholder="Από" title="Ημερομηνία αρχής">
+          <input id="addDue" type="datetime-local" placeholder="Μέχρι" title="Ημερομηνία λήξης">
         </div>
         <button class="success" id="addBtn">+ Προσθήκη</button>
       </div>
@@ -137,8 +137,8 @@
         </select>
         <input id="modalTags" placeholder="Ετικέτες (π.χ. Ηλεκτρικά,Μπάνιο)">
         <div class="dateInputs">
-          <input id="modalStart" type="date" placeholder="Από" title="Ημερομηνία αρχής">
-          <input id="modalDue" type="date" placeholder="Μέχρι" title="Ημερομηνία λήξης">
+          <input id="modalStart" type="datetime-local" placeholder="Από" title="Ημερομηνία αρχής">
+          <input id="modalDue" type="datetime-local" placeholder="Μέχρι" title="Ημερομηνία λήξης">
         </div>
       </div>
       <div class="actions">


### PR DESCRIPTION
## Summary
- migrate task start and due dates to `DATETIME`
- handle date+time in API and initialization
- use `datetime-local` inputs and display time in task list

## Testing
- `php -l api.php`
- `php -l app/bootstrap.php`
- `php -l index.php`
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4ea1770e88322bae827c160caff9c