### PR TITLE
Improve mobile task layout and typography

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -143,17 +143,19 @@ button.fab{display:none;width:56px;height:56px;border-radius:50%;background:var(
   .menuBtn{display:block}
 }
 @media (max-width:480px){
-  .page{padding:12px}
-  .meta{grid-template-columns:1fr;padding:0 12px 18px}
-  ul.tasks{grid-template-columns:1fr}
-  .notesWrap{grid-template-columns:1fr;padding:0 12px 28px}
-  .filters{grid-template-columns:1fr;padding:0 12px 12px}
+  .page{padding:clamp(12px,5vw,20px)}
+  .meta{grid-template-columns:1fr;padding:0 clamp(12px,5vw,20px) 18px}
+  ul.tasks{grid-template-columns:1fr;padding:8px clamp(12px,5vw,20px) 24px}
+  .notesWrap{grid-template-columns:1fr;padding:0 clamp(12px,5vw,28px)}
+  .filters{grid-template-columns:1fr;padding:0 clamp(12px,5vw,12px)}
   #addSectionTitle,.sidebar .addForm{display:none}
   button.fab{display:flex;position:fixed;bottom:20px;right:20px}
   .tagPrio{grid-template-columns:1fr}
   .editForm .dateInputs{grid-template-columns:1fr}
   .addForm .dateInputs{grid-template-columns:1fr}
-  .task{grid-template-columns:26px 28px minmax(0,1fr) auto;gap:8px;padding:10px}
+  .task{grid-template-columns:26px 28px minmax(0,1fr) auto;gap:8px;padding:clamp(14px,5vw,22px)}
+  .task label{font-size:clamp(1rem,4.5vw,1.25rem)}
+  .task .desc,.task .note{font-size:clamp(.875rem,3.8vw,1rem)}
   /* Full-screen editor on mobile */
   .task.editing{
     grid-template-columns:1fr;


### PR DESCRIPTION
## Summary
- refine mobile breakpoint padding and grid widths for full viewport use
- boost task padding and add clamp-based font sizing for better readability

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npx playwright install chromium` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ec9c623083228fc1cdbfaef502ab