### PR TITLE
Improve mobile task layout and typography

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -143,17 +143,22 @@ button.fab{display:none;width:56px;height:56px;border-radius:50%;background:var(
   .menuBtn{display:block}
 }
 @media (max-width:480px){
-  .page{padding:12px}
-  .meta{grid-template-columns:1fr;padding:0 12px 18px}
-  ul.tasks{grid-template-columns:1fr}
-  .notesWrap{grid-template-columns:1fr;padding:0 12px 28px}
-  .filters{grid-template-columns:1fr;padding:0 12px 12px}
+  .page{padding:clamp(12px,5vw,20px)}
+  .meta{grid-template-columns:1fr;padding:0 clamp(12px,5vw,20px) 18px}
+  ul.tasks{grid-template-columns:1fr;padding:8px clamp(12px,5vw,20px) 24px}
+  .notesWrap{grid-template-columns:1fr;padding:0 clamp(12px,5vw,28px)}
+  .filters{grid-template-columns:1fr;padding:0 clamp(12px,5vw,12px)}
   #addSectionTitle,.sidebar .addForm{display:none}
   button.fab{display:flex;position:fixed;bottom:20px;right:20px}
   .tagPrio{grid-template-columns:1fr}
   .editForm .dateInputs{grid-template-columns:1fr}
   .addForm .dateInputs{grid-template-columns:1fr}
-  .task{grid-template-columns:26px 28px minmax(0,1fr) auto;gap:8px;padding:10px}
+  .task{grid-template-columns:26px 28px minmax(0,1fr) auto;gap:8px;padding:clamp(14px,5vw,22px)}
+  .task label{font-size:clamp(1rem,4.5vw,1.25rem)}
+  .task .desc,.task .note{font-size:clamp(.875rem,3.8vw,1rem)}
+  .task .dates{flex-direction:column;align-items:flex-start}
+  .task .dates .sep{display:none}
+  *,*::before,*::after{transition:none !important;animation:none !important}
   /* Full-screen editor on mobile */
   .task.editing{
     grid-template-columns:1fr;
@@ -274,7 +279,16 @@ ul.tasks { gap: 14px; padding: 10px 18px 28px 18px; }
 .task.done label{ color:var(--muted); text-decoration: line-through; }
 
 /* Task dates */
-.task .dates{ font-size:12px; color:var(--muted); margin-top:4px; }
+.task .dates{
+  display:flex;
+  align-items:center;
+  gap:4px;
+  font-size:12px;
+  color:var(--muted);
+  margin-top:4px;
+}
+.task .dates::before{ content:'📅'; }
+.task .dates .sep{ margin:0 2px; }
 .task .dates .due{ color:var(--accent); font-weight:600; }
 
 /* Editing state */

--- a/assets/js/tasks.js
+++ b/assets/js/tasks.js
@@ -27,9 +27,9 @@ function renderChips(tags){
   return '<div class="chips">' + parts.map(t => `<span class="chip">${escapeHtml(t)}</span>`).join('') + '</div>';
 }
 function renderDates(start, due){
-  if (start && due) return `<div class="dates">📅 <span class="start">${escapeHtml(fmtDate(start))}</span> → <span class="due">${escapeHtml(fmtDate(due))}</span></div>`;
-  if (start)       return `<div class="dates">📅 Από <span class="start">${escapeHtml(fmtDate(start))}</span></div>`;
-  if (due)         return `<div class="dates">📅 Μέχρι <span class="due">${escapeHtml(fmtDate(due))}</span></div>`;
+  if (start && due) return `<div class="dates"><span class="start">${escapeHtml(fmtDate(start))}</span><span class="sep">→</span><span class="due">${escapeHtml(fmtDate(due))}</span></div>`;
+  if (start)       return `<div class="dates"><span class="start">Από ${escapeHtml(fmtDate(start))}</span></div>`;
+  if (due)         return `<div class="dates"><span class="due">Μέχρι ${escapeHtml(fmtDate(due))}</span></div>`;
   return '';
 }
 


### PR DESCRIPTION
## Summary
- refine mobile breakpoint padding and grid widths for full viewport use
- boost task padding and add clamp-based font sizing for better readability
- stack task dates vertically on phones and strip animations for smoother navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npx playwright install chromium` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ec9c623083228fc1cdbfaef502ab