### PR TITLE
style: make login page responsive

### DIFF
--- a/assets/css/login.css
+++ b/assets/css/login.css
@@ -1,0 +1,52 @@
+body.login .page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: 24px;
+  width: 100%;
+}
+
+body.login .card {
+  width: 100%;
+  max-width: 560px;
+  margin: 0;
+}
+
+body.login .meta {
+  grid-template-columns: 1fr;
+}
+
+body.login .field {
+  border: none;
+  padding: 0;
+}
+
+body.login .field input {
+  border: 1px solid var(--border);
+  background: #fff;
+  border-radius: 12px;
+  padding: 12px;
+  width: 100%;
+}
+
+body.login .error {
+  color: #b91c1c;
+  background: #fee2e2;
+  border: 1px solid #fecaca;
+  padding: 10px 12px;
+  border-radius: 12px;
+  margin: 0 28px 14px;
+}
+
+body.login .toolbar {
+  justify-content: flex-end;
+  padding: 0 28px 24px;
+}
+
+@media (max-width: 480px) {
+  body.login .page {
+    padding: clamp(12px, 5vw, 20px);
+  }
+}

--- a/login.php
+++ b/login.php
@@ -60,14 +60,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title><?= htmlspecialchars($mode === 'login' ? 'Σύνδεση' : 'Ορισμός κωδικού') ?> – <?= htmlspecialchars($list_name) ?></title>
   <link rel="stylesheet" href="assets/css/styles.css" />
-  <style>
-    .card { max-width: 560px; margin: 60px auto; }
-    .field input { border: 1px solid var(--border); background: #fff; border-radius: 12px; padding: 12px; width: 100%; }
-    .error { color: #b91c1c; background: #fee2e2; border: 1px solid #fecaca; padding: 10px 12px; border-radius: 12px; margin: 0 28px 14px; }
-    .toolbar { justify-content: flex-end; }
-  </style>
+  <link rel="stylesheet" href="assets/css/login.css" />
 </head>
-<body>
+<body class="login">
   <div class="page">
     <div class="card">
       <header>
@@ -81,23 +76,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <div class="error"><?= htmlspecialchars($error) ?></div>
       <?php endif; ?>
 
-      <form method="post" class="meta" style="grid-template-columns: 1fr;">
+        <form method="post" class="meta">
         <input type="hidden" name="csrf" value="<?= htmlspecialchars(csrf_token(), ENT_QUOTES) ?>">
         <input type="hidden" name="list_id" value="<?= (int)$list_id ?>">
 
-        <div class="field">
+          <div class="field">
           <label><?= $mode === 'login' ? 'Κωδικός πρόσβασης' : 'Νέος κωδικός πρόσβασης' ?></label>
-          <input type="password" name="password" required>
+          <input type="password" name="password" required autofocus autocomplete="<?= $mode === 'login' ? 'current-password' : 'new-password' ?>">
         </div>
 
         <?php if ($mode === 'setup'): ?>
           <div class="field">
             <label>Επιβεβαίωση κωδικού</label>
-            <input type="password" name="password2" required>
+            <input type="password" name="password2" required autocomplete="new-password">
           </div>
         <?php endif; ?>
 
-        <div class="toolbar" style="padding: 0 28px 24px;">
+          <div class="toolbar">
           <button class="success" type="submit"><?= $mode === 'login' ? 'Σύνδεση' : 'Αποθήκευση κωδικού' ?></button>
         </div>
       </form>


### PR DESCRIPTION
## Summary
- center login card with flexbox layout
- move login page styles to dedicated stylesheet
- add password autofill hints and polish markup

## Testing
- `php -l login.php`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8951f31908322bef6d31cbc532d45