### PR TITLE
Link login form labels to inputs

### DIFF
--- a/login.php
+++ b/login.php
@@ -84,14 +84,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       <input type="hidden" name="list_id" value="<?= (int)$list_id ?>">
 
       <div class="field">
-        <label><?= $mode === 'login' ? 'Κωδικός πρόσβασης' : 'Νέος κωδικός πρόσβασης' ?></label>
-        <input type="password" name="password" required autofocus autocomplete="<?= $mode === 'login' ? 'current-password' : 'new-password' ?>">
+        <label for="password"><?= $mode === 'login' ? 'Κωδικός πρόσβασης' : 'Νέος κωδικός πρόσβασης' ?></label>
+        <input id="password" type="password" name="password" required autofocus autocomplete="<?= $mode === 'login' ? 'current-password' : 'new-password' ?>">
       </div>
 
       <?php if ($mode === 'setup'): ?>
         <div class="field">
-          <label>Επιβεβαίωση κωδικού</label>
-          <input type="password" name="password2" required autocomplete="new-password">
+          <label for="password2">Επιβεβαίωση κωδικού</label>
+          <input id="password2" type="password" name="password2" required autocomplete="new-password">
         </div>
       <?php endif; ?>
 


### PR DESCRIPTION
## Summary
- add unique `id` attributes to login form inputs
- link `<label>` elements to their corresponding inputs via `for`

## Testing
- `php -l login.php`
- `php -r '$src=file_get_contents("login.php"); preg_match_all("/<input[^>]*id=\\"([^\\"]+)\\"/", $src,$inputs); preg_match_all("/<label[^>]*for=\\"([^\\"]+)\\"/", $src,$labels); foreach($labels[1] as $for){ echo (in_array($for,$inputs[1]) ? "label $for ok\\n" : "label $for missing\\n"); }'`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af594c31f88322b2d1efb147fda51b