### PR TITLE
Κεντραρισμένος τίτλος στη φόρμα σύνδεσης

### DIFF
--- a/assets/css/login.css
+++ b/assets/css/login.css
@@ -10,6 +10,12 @@ body.login {
   width: 100%;
 }
 
+body.login header {
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+}
+
 body.login .card {
   width: 100%;
   max-width: 560px;

--- a/login.php
+++ b/login.php
@@ -64,16 +64,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </head>
 <body class="login">
   <div class="card">
-    <header>
-      <div>
+      <header>
         <div class="title"><?= htmlspecialchars($list_name, ENT_QUOTES) ?></div>
         <div class="subtitle">
           <?= $mode === 'login'
             ? 'Πληκτρολογήστε τον κωδικό πρόσβασης για να δείτε τη λίστα.'
             : 'Ορίστε έναν αρχικό κωδικό πρόσβασης για τη λίστα.' ?>
         </div>
-      </div>
-    </header>
+      </header>
 
     <?php if ($error): ?>
       <div class="error"><?= htmlspecialchars($error, ENT_QUOTES) ?></div>


### PR DESCRIPTION
## ΠΕΡΙΛΗΨΗ
- Προστέθηκε CSS κανόνας για flex διάταξη του header στη σελίδα σύνδεσης.
- Αφαιρέθηκε περιττή δεύτερη στήλη στο login.php ώστε ο τίτλος να κεντραριστεί.

## ΕΛΕΓΧΟΙ
- `npm test` *(αποτυχία: Missing script: "test")*
- `php -l login.php`


------
https://chatgpt.com/codex/tasks/task_e_68af5bbb937c83228da667d303f86a1a