### PR TITLE
Use dedicated login-form class for login

### DIFF
--- a/assets/css/login.css
+++ b/assets/css/login.css
@@ -22,8 +22,11 @@ body.login .card {
   margin: 0;
 }
 
-body.login .meta {
-  grid-template-columns: 1fr;
+body.login .login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 0 28px 24px;
 }
 
 body.login .field {
@@ -50,7 +53,6 @@ body.login .error {
 
 body.login .toolbar {
   justify-content: flex-end;
-  padding: 0 28px 24px;
 }
 
 @media (max-width: 768px) {
@@ -66,7 +68,7 @@ body.login .toolbar {
   body.login .error {
     margin: 0 20px 14px;
   }
-  body.login .toolbar {
+  body.login .login-form {
     padding: 0 20px 24px;
   }
 }
@@ -74,5 +76,8 @@ body.login .toolbar {
 @media (max-width: 480px) {
   body.login {
     padding: clamp(12px, 5vw, 20px);
+  }
+  body.login .login-form {
+    padding: 0 clamp(12px, 5vw, 20px) 24px;
   }
 }

--- a/login.php
+++ b/login.php
@@ -77,7 +77,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       <div class="error"><?= htmlspecialchars($error, ENT_QUOTES) ?></div>
     <?php endif; ?>
 
-    <form method="post" class="meta">
+    <form method="post" class="login-form">
       <input type="hidden" name="csrf" value="<?= htmlspecialchars(csrf_token(), ENT_QUOTES) ?>">
       <input type="hidden" name="list_id" value="<?= (int)$list_id ?>">
 


### PR DESCRIPTION
## Summary
- Replace generic `meta` form class with specific `login-form`
- Add `.login-form` styles with column flex layout and responsive padding

## Testing
- `php -l login.php`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af5d287e8083228554ad697afbcfd1