### PR TITLE
feat: improve login page typography and accessibility

### DIFF
--- a/assets/css/login.css
+++ b/assets/css/login.css
@@ -16,10 +16,18 @@ body.login header {
   text-align: center;
 }
 
+body.login header .title {
+  font-size: clamp(24px, 5vw, 28px);
+}
+
+body.login header .subtitle {
+  font-size: clamp(13px, 2.5vw, 14px);
+}
+
 body.login .card {
   width: 100%;
   max-width: 560px;
-  margin: 0;
+  margin: 0 auto;
 }
 
 body.login .login-form {
@@ -40,6 +48,7 @@ body.login .field input {
   border-radius: 12px;
   padding: 12px;
   width: 100%;
+  min-height: 48px;
 }
 
 body.login .error {
@@ -57,17 +66,13 @@ body.login .toolbar {
 
 body.login .toolbar button {
   width: 100%;
+  font-size: clamp(16px, 4vw, 18px);
+  min-height: 48px;
 }
 
 @media (max-width: 768px) {
   body.login {
     padding: 20px;
-  }
-  body.login header .title {
-    font-size: 24px;
-  }
-  body.login header .subtitle {
-    font-size: 13px;
   }
   body.login .error {
     margin: 0 20px 14px;


### PR DESCRIPTION
## Summary
- Adjust login heading, subtitle and button text with fluid `clamp()` sizing
- Ensure login inputs and button have a minimum 48px height for easier tapping
- Center login card within the viewport for a more balanced layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af5e699ff08322a8c2990140941ef9